### PR TITLE
feat: p2tr output parsing

### DIFF
--- a/script/BTCUtils.s.sol
+++ b/script/BTCUtils.s.sol
@@ -1,12 +1,14 @@
 pragma solidity ^0.8.4;
 
-/** @title BitcoinSPV */
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title BitcoinSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {BTCUtils} from "../src/BTCUtils.sol";
 
 contract BTCUtilsScript {
-
     /* ***** */
     /* UTILS */
     /* ***** */
@@ -27,7 +29,6 @@ contract BTCUtilsScript {
     function parseVarInt(bytes memory _b) public returns (uint256, uint256) {
         return BTCUtils.parseVarInt(_b);
     }
-
 
     /// @notice          Changes the endianness of a byte array
     /// @dev             Returns a new, backwards, bytes
@@ -133,6 +134,7 @@ contract BTCUtilsScript {
     /// @dev             Will return hex"00" if passed a witness input
     /// @param _input    The LEGACY input
     /// @return          The length-prepended script sig
+
     function extractScriptSig(bytes memory _input) public returns (bytes memory) {
         return BTCUtils.extractScriptSig(_input);
     }
@@ -145,7 +147,6 @@ contract BTCUtilsScript {
         return BTCUtils.extractScriptSigLen(_input);
     }
 
-
     /* ************* */
     /* Witness Input */
     /* ************* */
@@ -157,7 +158,6 @@ contract BTCUtilsScript {
     function extractSequenceLEWitness(bytes memory _input) public returns (bytes4) {
         return BTCUtils.extractSequenceLEWitness(_input);
     }
-
 
     /// @notice          Extracts the sequence from the input in a tx
     /// @dev             Sequence is a 4-byte little-endian number
@@ -175,7 +175,6 @@ contract BTCUtilsScript {
         return BTCUtils.extractOutpoint(_input);
     }
 
-
     /// @notice          Extracts the outpoint tx id from an input
     /// @dev             32 byte tx id
     /// @param _input    The input
@@ -191,7 +190,6 @@ contract BTCUtilsScript {
     function extractTxIndexLE(bytes memory _input) public returns (bytes4) {
         return BTCUtils.extractTxIndexLE(_input);
     }
-
 
     /* ****** */
     /* Output */
@@ -250,7 +248,6 @@ contract BTCUtilsScript {
     /* Witness TX */
     /* ********** */
 
-
     /// @notice      Checks that the vin passed up is properly formatted
     /// @dev         Consider a vin with a valid vout in its scriptsig
     /// @param _vin  Raw bytes length-prefixed input vector
@@ -266,8 +263,6 @@ contract BTCUtilsScript {
     function validateVout(bytes memory _vout) public returns (bool) {
         return BTCUtils.validateVout(_vout);
     }
-
-
 
     /* ************ */
     /* Block Header */
@@ -343,7 +338,7 @@ contract BTCUtilsScript {
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) public returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint256 _index) public returns (bool) {
         return BTCUtils.verifyHash256Merkle(_proof, _index);
     }
 
@@ -359,11 +354,10 @@ contract BTCUtilsScript {
     /// @param _firstTimestamp  the timestamp of the first block in the difficulty period
     /// @param _secondTimestamp the timestamp of the last block in the difficulty period
     /// @return                 the new period's target threshold
-    function retargetAlgorithm(
-        uint256 _previousTarget,
-        uint256 _firstTimestamp,
-        uint256 _secondTimestamp
-    ) public returns (uint256) {
+    function retargetAlgorithm(uint256 _previousTarget, uint256 _firstTimestamp, uint256 _secondTimestamp)
+        public
+        returns (uint256)
+    {
         return BTCUtils.retargetAlgorithm(_previousTarget, _firstTimestamp, _secondTimestamp);
     }
 }

--- a/script/CheckBitcoinSigs.s.sol
+++ b/script/CheckBitcoinSigs.s.sol
@@ -1,12 +1,14 @@
 pragma solidity ^0.8.4;
 
-/** @title ValidateSPV*/
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title ValidateSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {CheckBitcoinSigs} from "../src/CheckBitcoinSigs.sol";
 
 contract CheckBitcoinSigsScript {
-
     /// @notice          Derives an Ethereum Account address from a pubkey
     /// @dev             The address is the last 20 bytes of the keccak256 of the address
     /// @param _pubkey   The public key X & Y. Unprefixed, as a 64-byte array
@@ -31,13 +33,7 @@ contract CheckBitcoinSigsScript {
     /// @param _r        the signature r value
     /// @param _s        the signature s value
     /// @return          true if signature is valid, else false
-    function checkSig(
-        bytes memory _pubkey,
-        bytes32 _digest,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
-    ) public returns (bool) {
+    function checkSig(bytes memory _pubkey, bytes32 _digest, uint8 _v, bytes32 _r, bytes32 _s) public returns (bool) {
         return CheckBitcoinSigs.checkSig(_pubkey, _digest, _v, _r, _s);
     }
 
@@ -58,23 +54,15 @@ contract CheckBitcoinSigsScript {
         bytes32 _r,
         bytes32 _s
     ) public returns (bool) {
-        return CheckBitcoinSigs.checkBitcoinSig(
-            _p2wpkhOutputScript,
-            _pubkey,
-            _digest,
-            _v,
-            _r,
-            _s);
+        return CheckBitcoinSigs.checkBitcoinSig(_p2wpkhOutputScript, _pubkey, _digest, _v, _r, _s);
     }
     /// @notice             checks if a message is the sha256 preimage of a digest
     /// @dev                this is NOT the hash256!  this step is necessary for ECDSA security!
     /// @param _digest      the digest
     /// @param _candidate   the purported preimage
     /// @return             true if the preimage matches the digest, else false
-    function isSha256Preimage(
-        bytes memory _candidate,
-        bytes32 _digest
-    ) public returns (bool) {
+
+    function isSha256Preimage(bytes memory _candidate, bytes32 _digest) public returns (bool) {
         return CheckBitcoinSigs.isSha256Preimage(_candidate, _digest);
     }
 
@@ -83,10 +71,7 @@ contract CheckBitcoinSigsScript {
     /// @param _digest      the digest
     /// @param _candidate   the purported preimage
     /// @return             true if the preimage matches the digest, else false
-    function isKeccak256Preimage(
-        bytes memory _candidate,
-        bytes32 _digest
-    ) public returns (bool) {
+    function isKeccak256Preimage(bytes memory _candidate, bytes32 _digest) public returns (bool) {
         return CheckBitcoinSigs.isKeccak256Preimage(_candidate, _digest);
     }
 
@@ -99,17 +84,12 @@ contract CheckBitcoinSigsScript {
     /// @param _outputPKH       the output pubkeyhash (hash160(recipient_pubkey))
     /// @return                 the double-sha256 (hash256) signature hash as defined by bip143
     function oneInputOneOutputSighash(
-        bytes memory _outpoint,  // 36 byte UTXO id
-        bytes20 _inputPKH,  // 20 byte hash160
-        bytes8 _inputValue,  // 8-byte LE
-        bytes8 _outputValue,  // 8-byte LE
-        bytes20 _outputPKH  // 20 byte hash160
+        bytes memory _outpoint, // 36 byte UTXO id
+        bytes20 _inputPKH, // 20 byte hash160
+        bytes8 _inputValue, // 8-byte LE
+        bytes8 _outputValue, // 8-byte LE
+        bytes20 _outputPKH // 20 byte hash160
     ) public returns (bytes32) {
-        return CheckBitcoinSigs.oneInputOneOutputSighash(
-            _outpoint,
-            _inputPKH,
-            _inputValue,
-            _outputValue,
-            _outputPKH);
+        return CheckBitcoinSigs.oneInputOneOutputSighash(_outpoint, _inputPKH, _inputValue, _outputValue, _outputPKH);
     }
 }

--- a/script/ValidateSPV.s.sol
+++ b/script/ValidateSPV.s.sol
@@ -1,10 +1,12 @@
 pragma solidity ^0.8.4;
 
-/** @title ValidateSPV*/
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title ValidateSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {ValidateSPV} from "../src/ValidateSPV.sol";
-
 
 contract ValidateSPVScript {
     function getErrBadLength() public pure returns (uint256) {
@@ -25,12 +27,7 @@ contract ValidateSPVScript {
     /// @param _proof           The proof (concatenated LE hashes)
     /// @param _index           The proof index
     /// @return                 true if fully valid, false otherwise
-    function prove(
-        bytes32 _txid,
-        bytes32 _merkleRoot,
-        bytes memory _proof,
-        uint _index
-    ) public returns (bool) {
+    function prove(bytes32 _txid, bytes32 _merkleRoot, bytes memory _proof, uint256 _index) public returns (bool) {
         return ValidateSPV.prove(_txid, _merkleRoot, _proof, _index);
     }
 
@@ -41,12 +38,10 @@ contract ValidateSPVScript {
     /// @param _vout        Raw bytes length-prefixed output vector
     /// @ param _locktime   4-byte tx locktime
     /// @return             32-byte transaction id, little endian
-    function calculateTxId(
-        bytes4 _version,
-        bytes memory _vin,
-        bytes memory _vout,
-        bytes4 _locktime
-    ) public returns (bytes32) {
+    function calculateTxId(bytes4 _version, bytes memory _vin, bytes memory _vout, bytes4 _locktime)
+        public
+        returns (bytes32)
+    {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }
 

--- a/src/BTCUtils.sol
+++ b/src/BTCUtils.sol
@@ -581,13 +581,17 @@ library BTCUtils {
             return hex"";
         }
 
-        if (uint8(_output[_at + 1]) == 0) {
+        // version opcode is 0x00 for p2wpkh and p2wsh, 0x51 for p2tr
+        uint256 _version = uint8(_output[_at + 1]);
+        if (_version == 0x00 || _version == 0x51) {
+            // p2wpkh, p2wsh, p2tr
             if (_scriptLen < 2) {
                 return hex"";
             }
             uint256 _payloadLen = uint8(_output[_at + 2]);
             // Check for maliciously formatted witness outputs.
             // No need to worry about underflow as long b/c of the `< 2` check
+            // p2wsh and p2tr have a payload length of 32 bytes, p2wpkh has a payload length of 20 bytes
             if (_payloadLen != _scriptLen - 2 || (_payloadLen != 0x20 && _payloadLen != 0x14)) {
                 return hex"";
             }

--- a/src/BTCUtils.sol
+++ b/src/BTCUtils.sol
@@ -1,8 +1,11 @@
 pragma solidity ^0.8.4;
 
-/** @title BitcoinSPV */
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title BitcoinSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {BytesLib} from "./BytesLib.sol";
 import {SafeMath} from "./SafeMath.sol";
 
@@ -13,8 +16,8 @@ library BTCUtils {
     // The target at minimum Difficulty. Also the target of the genesis block
     uint256 public constant DIFF1_TARGET = 0xffff0000000000000000000000000000000000000000000000000000;
 
-    uint256 public constant RETARGET_PERIOD = 2 * 7 * 24 * 60 * 60;  // 2 weeks in seconds
-    uint256 public constant RETARGET_PERIOD_BLOCKS = 2016;  // 2 weeks in blocks
+    uint256 public constant RETARGET_PERIOD = 2 * 7 * 24 * 60 * 60; // 2 weeks in seconds
+    uint256 public constant RETARGET_PERIOD_BLOCKS = 2016; // 2 weeks in blocks
 
     uint256 public constant ERR_BAD_ARG = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
@@ -37,16 +40,16 @@ library BTCUtils {
     /// @return         The number of non-flag bytes in the VarInt
     function determineVarIntDataLengthAt(bytes memory _b, uint256 _at) internal pure returns (uint8) {
         if (uint8(_b[_at]) == 0xff) {
-            return 8;  // one-byte flag, 8 bytes data
+            return 8; // one-byte flag, 8 bytes data
         }
         if (uint8(_b[_at]) == 0xfe) {
-            return 4;  // one-byte flag, 4 bytes data
+            return 4; // one-byte flag, 4 bytes data
         }
         if (uint8(_b[_at]) == 0xfd) {
-            return 2;  // one-byte flag, 2 bytes data
+            return 2; // one-byte flag, 2 bytes data
         }
 
-        return 0;  // flag is data
+        return 0; // flag is data
     }
 
     /// @notice     Parse a VarInt into its data length and the number it represents
@@ -91,7 +94,7 @@ library BTCUtils {
     function reverseEndianness(bytes memory _b) internal pure returns (bytes memory) {
         bytes memory _newValue = new bytes(_b.length);
 
-        for (uint i = 0; i < _b.length; i++) {
+        for (uint256 i = 0; i < _b.length; i++) {
             _newValue[_b.length - i - 1] = _b[i];
         }
 
@@ -106,17 +109,17 @@ library BTCUtils {
         v = _b;
 
         // swap bytes
-        v = ((v >> 8) & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) |
-            ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
+        v = ((v >> 8) & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF)
+            | ((v & 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF) << 8);
         // swap 2-byte long pairs
-        v = ((v >> 16) & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) |
-            ((v & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
+        v = ((v >> 16) & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF)
+            | ((v & 0x0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF) << 16);
         // swap 4-byte long pairs
-        v = ((v >> 32) & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) |
-            ((v & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
+        v = ((v >> 32) & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF)
+            | ((v & 0x00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF) << 32);
         // swap 8-byte long pairs
-        v = ((v >> 64) & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) |
-            ((v & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
+        v = ((v >> 64) & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF)
+            | ((v & 0x0000000000000000FFFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF) << 64);
         // swap 16-byte long pairs
         v = (v >> 128) | (v << 128);
     }
@@ -128,11 +131,9 @@ library BTCUtils {
         v = _b;
 
         // swap bytes
-        v = ((v >> 8) & 0x00FF00FF00FF00FF) |
-            ((v & 0x00FF00FF00FF00FF) << 8);
+        v = ((v >> 8) & 0x00FF00FF00FF00FF) | ((v & 0x00FF00FF00FF00FF) << 8);
         // swap 2-byte long pairs
-        v = ((v >> 16) & 0x0000FFFF0000FFFF) |
-            ((v & 0x0000FFFF0000FFFF) << 16);
+        v = ((v >> 16) & 0x0000FFFF0000FFFF) | ((v & 0x0000FFFF0000FFFF) << 16);
         // swap 4-byte long pairs
         v = (v >> 32) | (v << 32);
     }
@@ -144,8 +145,7 @@ library BTCUtils {
         v = _b;
 
         // swap bytes
-        v = ((v >> 8) & 0x00FF00FF) |
-            ((v & 0x00FF00FF) << 8);
+        v = ((v >> 8) & 0x00FF00FF) | ((v & 0x00FF00FF) << 8);
         // swap 2-byte long pairs
         v = (v >> 16) | (v << 16);
     }
@@ -154,16 +154,15 @@ library BTCUtils {
     /// @param _b        The unsigned integer to reverse
     /// @return v        The reversed value
     function reverseUint24(uint24 _b) internal pure returns (uint24 v) {
-        v =  (_b << 16) | (_b & 0x00FF00) | (_b >> 16);
+        v = (_b << 16) | (_b & 0x00FF00) | (_b >> 16);
     }
 
     /// @notice          Changes the endianness of a uint16
     /// @param _b        The unsigned integer to reverse
     /// @return v        The reversed value
     function reverseUint16(uint16 _b) internal pure returns (uint16 v) {
-        v =  (_b << 8) | (_b >> 8);
+        v = (_b << 8) | (_b >> 8);
     }
-
 
     /// @notice          Converts big-endian bytes to a uint
     /// @dev             Traverses the byte array and sums the bytes
@@ -172,7 +171,7 @@ library BTCUtils {
     function bytesToUint(bytes memory _b) internal pure returns (uint256) {
         uint256 _number;
 
-        for (uint i = 0; i < _b.length; i++) {
+        for (uint256 i = 0; i < _b.length; i++) {
             _number = _number + uint8(_b[i]) * (2 ** (8 * (_b.length - (i + 1))));
         }
 
@@ -254,11 +253,7 @@ library BTCUtils {
     /// @param at        The start of the pre-image
     /// @param len       The length of the pre-image
     /// @return res      The digest
-    function hash256Slice(
-        bytes memory _b,
-        uint256 at,
-        uint256 len
-    ) internal view returns (bytes32 res) {
+    function hash256Slice(bytes memory _b, uint256 at, uint256 len) internal view returns (bytes32 res) {
         // solium-disable-next-line security/no-inline-assembly
         assembly {
             pop(staticcall(gas(), 2, add(_b, add(32, at)), len, 0x00, 32))
@@ -287,7 +282,7 @@ library BTCUtils {
         uint256 _len = 0;
         uint256 _offset = 1 + _varIntDataLen;
 
-        for (uint256 _i = 0; _i < _index; _i ++) {
+        for (uint256 _i = 0; _i < _index; _i++) {
             _len = determineInputLengthAt(_vin, _offset);
             require(_len != ERR_BAD_ARG, "Bad VarInt in scriptSig");
             _offset = _offset + _len;
@@ -382,6 +377,7 @@ library BTCUtils {
     /// @dev             Will return hex"00" if passed a witness input
     /// @param _input    The LEGACY input
     /// @return          The length-prepended scriptSig
+
     function extractScriptSig(bytes memory _input) internal pure returns (bytes memory) {
         uint256 _varIntDataLen;
         uint256 _scriptSigLen;
@@ -389,7 +385,6 @@ library BTCUtils {
         require(_varIntDataLen != ERR_BAD_ARG, "Bad VarInt in scriptSig");
         return _input.slice(36, 1 + _varIntDataLen + _scriptSigLen);
     }
-
 
     /* ************* */
     /* Witness Input */
@@ -507,7 +502,7 @@ library BTCUtils {
         uint256 _len = 0;
         uint256 _offset = 1 + _varIntDataLen;
 
-        for (uint256 _i = 0; _i < _index; _i ++) {
+        for (uint256 _i = 0; _i < _index; _i++) {
             _len = determineOutputLengthAt(_vout, _offset);
             require(_len != ERR_BAD_ARG, "Bad VarInt in scriptPubkey");
             _offset += _len;
@@ -575,11 +570,7 @@ library BTCUtils {
     /// @param _len      The length of the output script
     ///                  (output length - 8)
     /// @return          The hash committed to by the pk_script, or null for errors
-    function extractHashAt(
-        bytes memory _output,
-        uint256 _at,
-        uint256 _len
-    ) internal pure returns (bytes memory) {
+    function extractHashAt(bytes memory _output, uint256 _at, uint256 _len) internal pure returns (bytes memory) {
         uint8 _scriptLen = uint8(_output[_at]);
 
         // don't have to worry about overflow here.
@@ -607,12 +598,11 @@ library BTCUtils {
             if (_tag == hex"1976a9") {
                 // Check for maliciously formatted p2pkh
                 // No need to worry about underflow, b/c of _scriptLen check
-                if (uint8(_output[_at + 3]) != 0x14 ||
-                    _output.slice2(_at + _len - 2) != hex"88ac") {
+                if (uint8(_output[_at + 3]) != 0x14 || _output.slice2(_at + _len - 2) != hex"88ac") {
                     return hex"";
                 }
                 return _output.slice(_at + 4, 20);
-            //p2sh
+                //p2sh
             } else if (_tag == hex"17a914") {
                 // Check for maliciously formatted p2sh
                 // No need to worry about underflow, b/c of _scriptLen check
@@ -622,13 +612,12 @@ library BTCUtils {
                 return _output.slice(_at + 3, 20);
             }
         }
-        return hex"";  /* NB: will trigger on OPRETURN and any non-standard that doesn't overrun */
+        return hex""; /* NB: will trigger on OPRETURN and any non-standard that doesn't overrun */
     }
 
     /* ********** */
     /* Witness TX */
     /* ********** */
-
 
     /// @notice      Checks that the vin passed up is properly formatted
     /// @dev         Consider a vin with a valid vout in its scriptsig
@@ -704,8 +693,6 @@ library BTCUtils {
         return _offset == _vout.length;
     }
 
-
-
     /* ************ */
     /* Block Header */
     /* ************ */
@@ -735,7 +722,7 @@ library BTCUtils {
         uint24 _m = uint24(_header.slice3(72 + at));
         uint8 _e = uint8(_header[75 + at]);
         uint256 _mantissa = uint256(reverseUint24(_m));
-        uint _exponent = _e - 3;
+        uint256 _exponent = _e - 3;
 
         return _mantissa * (256 ** _exponent);
     }
@@ -763,10 +750,7 @@ library BTCUtils {
     /// @param _header   The array containing the header
     /// @param at        The start of the header
     /// @return          The previous block's hash (little-endian)
-    function extractPrevBlockLEAt(
-        bytes memory _header,
-        uint256 at
-    ) internal pure returns (bytes32) {
+    function extractPrevBlockLEAt(bytes memory _header, uint256 at) internal pure returns (bytes32) {
         return _header.slice32(4 + at);
     }
 
@@ -810,13 +794,12 @@ library BTCUtils {
         return hash256Pair(_a, _b);
     }
 
-
     /// @notice          Verifies a Bitcoin-style merkle tree
     /// @dev             Leaves are 0-indexed. Inefficient version.
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) internal view returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint256 _index) internal view returns (bool) {
         // Not an even number of hashes
         if (_proof.length % 32 != 0) {
             return false;
@@ -847,12 +830,11 @@ library BTCUtils {
     /// @param _root     The root of the proof. LE sha256 hash.
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(
-        bytes32 _leaf,
-        bytes memory _tree,
-        bytes32 _root,
-        uint _index
-    ) internal view returns (bool) {
+    function verifyHash256Merkle(bytes32 _leaf, bytes memory _tree, bytes32 _root, uint256 _index)
+        internal
+        view
+        returns (bool)
+    {
         // Not an even number of hashes
         if (_tree.length % 32 != 0) {
             return false;
@@ -863,11 +845,11 @@ library BTCUtils {
             return false;
         }
 
-        uint _idx = _index;
+        uint256 _idx = _index;
         bytes32 _current = _leaf;
 
         // i moves in increments of 32
-        for (uint i = 0; i < _tree.length; i += 32) {
+        for (uint256 i = 0; i < _tree.length; i += 32) {
             if (_idx % 2 == 1) {
                 _current = _hash256MerkleStep(_tree.slice32(i), _current);
             } else {
@@ -890,11 +872,11 @@ library BTCUtils {
     /// @param _firstTimestamp  the timestamp of the first block in the difficulty period
     /// @param _secondTimestamp the timestamp of the last block in the difficulty period
     /// @return                 the new period's target threshold
-    function retargetAlgorithm(
-        uint256 _previousTarget,
-        uint256 _firstTimestamp,
-        uint256 _secondTimestamp
-    ) internal pure returns (uint256) {
+    function retargetAlgorithm(uint256 _previousTarget, uint256 _firstTimestamp, uint256 _secondTimestamp)
+        internal
+        pure
+        returns (uint256)
+    {
         uint256 _elapsedTime = _secondTimestamp.sub(_firstTimestamp);
 
         // Normalize ratio to factor of 4 if very long or very short

--- a/src/BTCUtils.sol
+++ b/src/BTCUtils.sol
@@ -1,14 +1,11 @@
 pragma solidity ^0.8.4;
 
-/**
- * @title BitcoinSPV
- */
-/**
- * @author Summa (https://summa.one)
- */
 import {BytesLib} from "./BytesLib.sol";
 import {SafeMath} from "./SafeMath.sol";
 
+/// @title BTCUtils
+/// @author Summa (https://github.com/summa-tx) and Bob (https://github.com/bob-collective)
+/// @notice Utility library for Bitcoin Actions
 library BTCUtils {
     using BytesLib for bytes;
     using SafeMath for uint256;

--- a/src/BTCUtilsDelegate.sol
+++ b/src/BTCUtilsDelegate.sol
@@ -1,12 +1,14 @@
 pragma solidity ^0.8.4;
 
-/** @title BitcoinSPV */
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title BitcoinSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {BTCUtils} from "./BTCUtils.sol";
 
 library BTCUtilsDelegate {
-
     /* ***** */
     /* UTILS */
     /* ***** */
@@ -124,6 +126,7 @@ library BTCUtilsDelegate {
     /// @dev             Will return hex"00" if passed a witness input
     /// @param _input    The LEGACY input
     /// @return          The length-prepended script sig
+
     function extractScriptSig(bytes memory _input) public pure returns (bytes memory) {
         return BTCUtils.extractScriptSig(_input);
     }
@@ -136,7 +139,6 @@ library BTCUtilsDelegate {
         return BTCUtils.extractScriptSigLen(_input);
     }
 
-
     /* ************* */
     /* Witness Input */
     /* ************* */
@@ -148,7 +150,6 @@ library BTCUtilsDelegate {
     function extractSequenceLEWitness(bytes memory _input) public pure returns (bytes4) {
         return BTCUtils.extractSequenceLEWitness(_input);
     }
-
 
     /// @notice          Extracts the sequence from the input in a tx
     /// @dev             Sequence is a 4-byte little-endian number
@@ -165,7 +166,6 @@ library BTCUtilsDelegate {
     function extractOutpoint(bytes memory _input) public pure returns (bytes memory) {
         return BTCUtils.extractOutpoint(_input);
     }
-
 
     /// @notice          Extracts the outpoint tx id from an input
     /// @dev             32 byte tx id
@@ -240,7 +240,6 @@ library BTCUtilsDelegate {
     /* Witness TX */
     /* ********** */
 
-
     /// @notice      Checks that the vin passed up is properly formatted
     /// @dev         Consider a vin with a valid vout in its scriptsig
     /// @param _vin  Raw bytes length-prefixed input vector
@@ -256,8 +255,6 @@ library BTCUtilsDelegate {
     function validateVout(bytes memory _vout) public pure returns (bool) {
         return BTCUtils.validateVout(_vout);
     }
-
-
 
     /* ************ */
     /* Block Header */
@@ -333,7 +330,7 @@ library BTCUtilsDelegate {
     /// @param _proof    The proof. Tightly packed LE sha256 hashes. The last hash is the root
     /// @param _index    The index of the leaf
     /// @return          true if the proof is valid, else false
-    function verifyHash256Merkle(bytes memory _proof, uint _index) public view returns (bool) {
+    function verifyHash256Merkle(bytes memory _proof, uint256 _index) public view returns (bool) {
         return BTCUtils.verifyHash256Merkle(_proof, _index);
     }
 
@@ -349,11 +346,11 @@ library BTCUtilsDelegate {
     /// @param _firstTimestamp  the timestamp of the first block in the difficulty period
     /// @param _secondTimestamp the timestamp of the last block in the difficulty period
     /// @return                 the new period's target threshold
-    function retargetAlgorithm(
-        uint256 _previousTarget,
-        uint256 _firstTimestamp,
-        uint256 _secondTimestamp
-    ) public pure returns (uint256) {
+    function retargetAlgorithm(uint256 _previousTarget, uint256 _firstTimestamp, uint256 _secondTimestamp)
+        public
+        pure
+        returns (uint256)
+    {
         return BTCUtils.retargetAlgorithm(_previousTarget, _firstTimestamp, _secondTimestamp);
     }
 }

--- a/src/BytesLib.sol
+++ b/src/BytesLib.sol
@@ -30,10 +30,12 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 */
 
-
-/** @title BytesLib **/
-/** @author https://github.com/GNSPS **/
-
+/**
+ * @title BytesLib *
+ */
+/**
+ * @author https://github.com/GNSPS *
+ */
 library BytesLib {
     function concat(bytes memory _preBytes, bytes memory _postBytes) internal pure returns (bytes memory) {
         bytes memory tempBytes;
@@ -83,24 +85,23 @@ library BytesLib {
             // length of the arrays.
             end := add(mc, length)
 
-            for {
-                let cc := add(_postBytes, 0x20)
-            } lt(mc, end) {
+            for { let cc := add(_postBytes, 0x20) } lt(mc, end) {
                 mc := add(mc, 0x20)
                 cc := add(cc, 0x20)
-            } {
-                mstore(mc, mload(cc))
-            }
+            } { mstore(mc, mload(cc)) }
 
             // Update the free-memory pointer by padding our last write location
             // to 32 bytes: add 31 bytes to the end of tempBytes to move to the
             // next 32 byte block, then round down to the nearest multiple of
             // 32. If the sum of the length of the two arrays is zero then add
             // one before rounding down to leave a blank 32 bytes (the length block with 0).
-            mstore(0x40, and(
-                add(add(end, iszero(add(length, mload(_preBytes)))), 31),
-                not(31) // Round down to the nearest 32 bytes.
-            ))
+            mstore(
+                0x40,
+                and(
+                    add(add(end, iszero(add(length, mload(_preBytes)))), 31),
+                    not(31) // Round down to the nearest 32 bytes.
+                )
+            )
         }
 
         return tempBytes;
@@ -145,14 +146,14 @@ library BytesLib {
                                     mload(add(_postBytes, 0x20)),
                                     // zero all bytes to the right
                                     exp(0x100, sub(32, mlength))
-                        ),
-                        // and now shift left the number of bytes to
-                        // leave space for the length in the slot
-                        exp(0x100, sub(32, newlength))
-                        ),
-                        // increase length by the double of the memory
-                        // bytes length
-                        mul(mlength, 2)
+                                ),
+                                // and now shift left the number of bytes to
+                                // leave space for the length in the slot
+                                exp(0x100, sub(32, newlength))
+                            ),
+                            // increase length by the double of the memory
+                            // bytes length
+                            mul(mlength, 2)
                         )
                     )
                 )
@@ -184,11 +185,8 @@ library BytesLib {
                 sstore(
                     sc,
                     add(
-                        and(
-                            fslot,
-                            0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00
-                    ),
-                    and(mload(mc), mask)
+                        and(fslot, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00),
+                        and(mload(mc), mask)
                     )
                 )
 
@@ -198,9 +196,7 @@ library BytesLib {
                 } lt(mc, end) {
                     sc := add(sc, 1)
                     mc := add(mc, 0x20)
-                } {
-                    sstore(sc, mload(mc))
-                }
+                } { sstore(sc, mload(mc)) }
 
                 mask := exp(0x100, sub(mc, end))
 
@@ -232,9 +228,7 @@ library BytesLib {
                 } lt(mc, end) {
                     sc := add(sc, 1)
                     mc := add(mc, 0x20)
-                } {
-                    sstore(sc, mload(mc))
-                }
+                } { sstore(sc, mload(mc)) }
 
                 mask := exp(0x100, sub(mc, end))
 
@@ -243,11 +237,11 @@ library BytesLib {
         }
     }
 
-    function slice(bytes memory _bytes, uint _start, uint _length) internal  pure returns (bytes memory res) {
+    function slice(bytes memory _bytes, uint256 _start, uint256 _length) internal pure returns (bytes memory res) {
         if (_length == 0) {
             return hex"";
         }
-        uint _end = _start + _length;
+        uint256 _end = _start + _length;
         require(_end > _start && _bytes.length >= _end, "Slice out of bounds");
 
         assembly {
@@ -262,11 +256,7 @@ library BytesLib {
             for {
                 let src := add(add(_bytes, 32), _start)
                 let end := add(src, _length)
-            } lt(src, end) {
-                src := add(src, 32)
-            } {
-                mstore(add(src, diff), mload(src))
-            }
+            } lt(src, end) { src := add(src, 32) } { mstore(add(src, diff), mload(src)) }
         }
     }
 
@@ -276,13 +266,9 @@ library BytesLib {
     /// @param _bytes The source array
     /// @param _dest The destination array.
     /// @param _start The location to start in the source array.
-    function sliceInPlace(
-        bytes memory _bytes,
-        bytes memory _dest,
-        uint _start
-    ) internal pure {
-        uint _length = _dest.length;
-        uint _end = _start + _length;
+    function sliceInPlace(bytes memory _bytes, bytes memory _dest, uint256 _start) internal pure {
+        uint256 _length = _dest.length;
+        uint256 _end = _start + _length;
         require(_end > _start && _bytes.length >= _end, "Slice out of bounds");
 
         assembly {
@@ -293,47 +279,45 @@ library BytesLib {
             } lt(src, end) {
                 src := add(src, 32)
                 res := add(res, 32)
-            } {
-                mstore(res, mload(src))
-            }
+            } { mstore(res, mload(src)) }
         }
     }
 
     // Static slice functions, no bounds checking
     /// @notice take a 32-byte slice from the specified position
-    function slice32(bytes memory _bytes, uint _start) internal pure returns (bytes32 res) {
+    function slice32(bytes memory _bytes, uint256 _start) internal pure returns (bytes32 res) {
         assembly {
             res := mload(add(add(_bytes, 32), _start))
         }
     }
 
     /// @notice take a 20-byte slice from the specified position
-    function slice20(bytes memory _bytes, uint _start) internal pure returns (bytes20) {
+    function slice20(bytes memory _bytes, uint256 _start) internal pure returns (bytes20) {
         return bytes20(slice32(_bytes, _start));
     }
 
     /// @notice take a 8-byte slice from the specified position
-    function slice8(bytes memory _bytes, uint _start) internal pure returns (bytes8) {
+    function slice8(bytes memory _bytes, uint256 _start) internal pure returns (bytes8) {
         return bytes8(slice32(_bytes, _start));
     }
 
     /// @notice take a 4-byte slice from the specified position
-    function slice4(bytes memory _bytes, uint _start) internal pure returns (bytes4) {
+    function slice4(bytes memory _bytes, uint256 _start) internal pure returns (bytes4) {
         return bytes4(slice32(_bytes, _start));
     }
 
     /// @notice take a 3-byte slice from the specified position
-    function slice3(bytes memory _bytes, uint _start) internal pure returns (bytes3) {
+    function slice3(bytes memory _bytes, uint256 _start) internal pure returns (bytes3) {
         return bytes3(slice32(_bytes, _start));
     }
 
     /// @notice take a 2-byte slice from the specified position
-    function slice2(bytes memory _bytes, uint _start) internal pure returns (bytes2) {
+    function slice2(bytes memory _bytes, uint256 _start) internal pure returns (bytes2) {
         return bytes2(slice32(_bytes, _start));
     }
 
-    function toAddress(bytes memory _bytes, uint _start) internal  pure returns (address) {
-        uint _totalLen = _start + 20;
+    function toAddress(bytes memory _bytes, uint256 _start) internal pure returns (address) {
+        uint256 _totalLen = _start + 20;
         require(_totalLen > _start && _bytes.length >= _totalLen, "Address conversion out of bounds.");
         address tempAddress;
 
@@ -344,8 +328,8 @@ library BytesLib {
         return tempAddress;
     }
 
-    function toUint(bytes memory _bytes, uint _start) internal  pure returns (uint256) {
-        uint _totalLen = _start + 32;
+    function toUint(bytes memory _bytes, uint256 _start) internal pure returns (uint256) {
+        uint256 _totalLen = _start + 32;
         require(_totalLen > _start && _bytes.length >= _totalLen, "Uint conversion out of bounds.");
         uint256 tempUint;
 
@@ -374,11 +358,10 @@ library BytesLib {
                 let mc := add(_preBytes, 0x20)
                 let end := add(mc, length)
 
-                for {
-                    let cc := add(_postBytes, 0x20)
-                    // the next line is the loop condition:
-                    // while(uint(mc < end) + cb == 2)
-                } eq(add(lt(mc, end), cb), 2) {
+                for { let cc := add(_postBytes, 0x20) }
+                // the next line is the loop condition:
+                // while(uint(mc < end) + cb == 2)
+                eq(add(lt(mc, end), cb), 2) {
                     mc := add(mc, 0x20)
                     cc := add(cc, 0x20)
                 } {
@@ -464,7 +447,7 @@ library BytesLib {
         return success;
     }
 
-    function toBytes32(bytes memory _source) pure internal returns (bytes32 result) {
+    function toBytes32(bytes memory _source) internal pure returns (bytes32 result) {
         if (_source.length == 0) {
             return 0x0;
         }
@@ -474,8 +457,12 @@ library BytesLib {
         }
     }
 
-    function keccak256Slice(bytes memory _bytes, uint _start, uint _length) pure internal returns (bytes32 result) {
-        uint _end = _start + _length;
+    function keccak256Slice(bytes memory _bytes, uint256 _start, uint256 _length)
+        internal
+        pure
+        returns (bytes32 result)
+    {
+        uint256 _end = _start + _length;
         require(_end > _start && _bytes.length >= _end, "Slice out of bounds");
 
         assembly {

--- a/src/CheckBitcoinSigs.sol
+++ b/src/CheckBitcoinSigs.sol
@@ -1,14 +1,15 @@
 pragma solidity ^0.8.4;
 
-/** @title CheckBitcoinSigs */
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title CheckBitcoinSigs
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {BytesLib} from "./BytesLib.sol";
 import {BTCUtils} from "./BTCUtils.sol";
 
-
 library CheckBitcoinSigs {
-
     using BytesLib for bytes;
     using BTCUtils for bytes;
 
@@ -56,13 +57,11 @@ library CheckBitcoinSigs {
     /// @param _r        the signature r value
     /// @param _s        the signature s value
     /// @return          true if signature is valid, else false
-    function checkSig(
-        bytes memory _pubkey,
-        bytes32 _digest,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
-    ) internal pure returns (bool) {
+    function checkSig(bytes memory _pubkey, bytes32 _digest, uint8 _v, bytes32 _r, bytes32 _s)
+        internal
+        pure
+        returns (bool)
+    {
         require(_pubkey.length == 64, "Requires uncompressed unprefixed pubkey");
         address _expected = accountFromPubkey(_pubkey);
         address _actual = ecrecover(_digest, _v, _r, _s);
@@ -88,8 +87,8 @@ library CheckBitcoinSigs {
     ) internal view returns (bool) {
         require(_pubkey.length == 64, "Requires uncompressed unprefixed pubkey");
 
-        bool _isExpectedSigner = keccak256(p2wpkhFromPubkey(_pubkey)) == keccak256(_p2wpkhOutputScript);  // is it the expected signer?
-        if (!_isExpectedSigner) {return false;}
+        bool _isExpectedSigner = keccak256(p2wpkhFromPubkey(_pubkey)) == keccak256(_p2wpkhOutputScript); // is it the expected signer?
+        if (!_isExpectedSigner) return false;
 
         bool _sigResult = checkSig(_pubkey, _digest, _v, _r, _s);
         return _sigResult;
@@ -100,10 +99,7 @@ library CheckBitcoinSigs {
     /// @param _digest      the digest
     /// @param _candidate   the purported preimage
     /// @return             true if the preimage matches the digest, else false
-    function isSha256Preimage(
-        bytes memory _candidate,
-        bytes32 _digest
-    ) internal pure returns (bool) {
+    function isSha256Preimage(bytes memory _candidate, bytes32 _digest) internal pure returns (bool) {
         return sha256(_candidate) == _digest;
     }
 
@@ -112,10 +108,7 @@ library CheckBitcoinSigs {
     /// @param _digest      the digest
     /// @param _candidate   the purported preimage
     /// @return             true if the preimage matches the digest, else false
-    function isKeccak256Preimage(
-        bytes memory _candidate,
-        bytes32 _digest
-    ) internal pure returns (bool) {
+    function isKeccak256Preimage(bytes memory _candidate, bytes32 _digest) internal pure returns (bool) {
         return keccak256(_candidate) == _digest;
     }
 
@@ -128,11 +121,11 @@ library CheckBitcoinSigs {
     /// @param _outputScript    the length-prefixed output script
     /// @return                 the double-sha256 (hash256) signature hash as defined by bip143
     function wpkhSpendSighash(
-        bytes memory _outpoint,  // 36-byte UTXO id
-        bytes20 _inputPKH,       // 20-byte hash160
-        bytes8 _inputValue,      // 8-byte LE
-        bytes8 _outputValue,     // 8-byte LE
-        bytes memory _outputScript    // lenght-prefixed output script
+        bytes memory _outpoint, // 36-byte UTXO id
+        bytes20 _inputPKH, // 20-byte hash160
+        bytes8 _inputValue, // 8-byte LE
+        bytes8 _outputValue, // 8-byte LE
+        bytes memory _outputScript // lenght-prefixed output script
     ) internal view returns (bytes32) {
         // Fixes elements to easily make a 1-in 1-out sighash digest
         // Does not support timelocks
@@ -141,25 +134,24 @@ library CheckBitcoinSigs {
         //     _inputPKH,
         //     hex"88ac");  // equal, checksig
 
-        bytes32 _hashOutputs = abi.encodePacked(
-            _outputValue,  // 8-byte LE
-            _outputScript).hash256View();
+        bytes32 _hashOutputs = abi.encodePacked(_outputValue, _outputScript) // 8-byte LE
+            .hash256View();
 
         bytes memory _sighashPreimage = abi.encodePacked(
-            hex"01000000",  // version
-            _outpoint.hash256View(),  // hashPrevouts
-            hex"8cb9012517c817fead650287d61bdd9c68803b6bf9c64133dcab3e65b5a50cb9",  // hashSequence(00000000)
-            _outpoint,  // outpoint
+            hex"01000000", // version
+            _outpoint.hash256View(), // hashPrevouts
+            hex"8cb9012517c817fead650287d61bdd9c68803b6bf9c64133dcab3e65b5a50cb9", // hashSequence(00000000)
+            _outpoint, // outpoint
             // p2wpkh script code
-            hex"1976a914",  // length, dup, hash160, pkh_length
+            hex"1976a914", // length, dup, hash160, pkh_length
             _inputPKH,
-            hex"88ac",  // equal, checksig
+            hex"88ac", // equal, checksig
             // end script code
-            _inputValue,  // value of the input in 8-byte LE
-            hex"00000000",  // input nSequence
-            _hashOutputs,  // hash of the single output
-            hex"00000000",  // nLockTime
-            hex"01000000"  // SIGHASH_ALL
+            _inputValue, // value of the input in 8-byte LE
+            hex"00000000", // input nSequence
+            _hashOutputs, // hash of the single output
+            hex"00000000", // nLockTime
+            hex"01000000" // SIGHASH_ALL
         );
         return _sighashPreimage.hash256View();
     }
@@ -173,11 +165,11 @@ library CheckBitcoinSigs {
     /// @param _outputPKH       the output pubkeyhash (hash160(recipient_pubkey))
     /// @return                 the double-sha256 (hash256) signature hash as defined by bip143
     function wpkhToWpkhSighash(
-        bytes memory _outpoint,  // 36-byte UTXO id
-        bytes20 _inputPKH,  // 20-byte hash160
-        bytes8 _inputValue,  // 8-byte LE
-        bytes8 _outputValue,  // 8-byte LE
-        bytes20 _outputPKH  // 20-byte hash160
+        bytes memory _outpoint, // 36-byte UTXO id
+        bytes20 _inputPKH, // 20-byte hash160
+        bytes8 _inputValue, // 8-byte LE
+        bytes8 _outputValue, // 8-byte LE
+        bytes20 _outputPKH // 20-byte hash160
     ) internal view returns (bytes32) {
         return wpkhSpendSighash(
             _outpoint,
@@ -185,9 +177,10 @@ library CheckBitcoinSigs {
             _inputValue,
             _outputValue,
             abi.encodePacked(
-              hex"160014",  // wpkh tag
-              _outputPKH)
-            );
+                hex"160014", // wpkh tag
+                _outputPKH
+            )
+        );
     }
 
     /// @notice                 Preserved for API compatibility with older version
@@ -199,13 +192,12 @@ library CheckBitcoinSigs {
     /// @param _outputPKH       the output pubkeyhash (hash160(recipient_pubkey))
     /// @return                 the double-sha256 (hash256) signature hash as defined by bip143
     function oneInputOneOutputSighash(
-        bytes memory _outpoint,  // 36-byte UTXO id
-        bytes20 _inputPKH,  // 20-byte hash160
-        bytes8 _inputValue,  // 8-byte LE
-        bytes8 _outputValue,  // 8-byte LE
-        bytes20 _outputPKH  // 20-byte hash160
+        bytes memory _outpoint, // 36-byte UTXO id
+        bytes20 _inputPKH, // 20-byte hash160
+        bytes8 _inputValue, // 8-byte LE
+        bytes8 _outputValue, // 8-byte LE
+        bytes20 _outputPKH // 20-byte hash160
     ) internal view returns (bytes32) {
         return wpkhToWpkhSighash(_outpoint, _inputPKH, _inputValue, _outputValue, _outputPKH);
     }
-
 }

--- a/src/CheckBitcoinSigsDelegate.sol
+++ b/src/CheckBitcoinSigsDelegate.sol
@@ -1,12 +1,14 @@
 pragma solidity ^0.8.4;
 
-/** @title ValidateSPV*/
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title ValidateSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {CheckBitcoinSigs} from "./CheckBitcoinSigs.sol";
 
 library CheckBitcoinSigsDelegate {
-
     /// @notice          Derives an Ethereum Account address from a pubkey
     /// @dev             The address is the last 20 bytes of the keccak256 of the address
     /// @param _pubkey   The public key X & Y. Unprefixed, as a 64-byte array
@@ -31,13 +33,11 @@ library CheckBitcoinSigsDelegate {
     /// @param _r        the signature r value
     /// @param _s        the signature s value
     /// @return          true if signature is valid, else false
-    function checkSig(
-        bytes memory _pubkey,
-        bytes32 _digest,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
-    ) public pure returns (bool) {
+    function checkSig(bytes memory _pubkey, bytes32 _digest, uint8 _v, bytes32 _r, bytes32 _s)
+        public
+        pure
+        returns (bool)
+    {
         return CheckBitcoinSigs.checkSig(_pubkey, _digest, _v, _r, _s);
     }
 
@@ -58,23 +58,15 @@ library CheckBitcoinSigsDelegate {
         bytes32 _r,
         bytes32 _s
     ) public view returns (bool) {
-        return CheckBitcoinSigs.checkBitcoinSig(
-            _p2wpkhOutputScript,
-            _pubkey,
-            _digest,
-            _v,
-            _r,
-            _s);
+        return CheckBitcoinSigs.checkBitcoinSig(_p2wpkhOutputScript, _pubkey, _digest, _v, _r, _s);
     }
     /// @notice             checks if a message is the sha256 preimage of a digest
     /// @dev                this is NOT the hash256!  this step is necessary for ECDSA security!
     /// @param _digest      the digest
     /// @param _candidate   the purported preimage
     /// @return             true if the preimage matches the digest, else false
-    function isSha256Preimage(
-        bytes memory _candidate,
-        bytes32 _digest
-    ) public pure returns (bool) {
+
+    function isSha256Preimage(bytes memory _candidate, bytes32 _digest) public pure returns (bool) {
         return CheckBitcoinSigs.isSha256Preimage(_candidate, _digest);
     }
 
@@ -83,10 +75,7 @@ library CheckBitcoinSigsDelegate {
     /// @param _digest      the digest
     /// @param _candidate   the purported preimage
     /// @return             true if the preimage matches the digest, else false
-    function isKeccak256Preimage(
-        bytes memory _candidate,
-        bytes32 _digest
-    ) public pure returns (bool) {
+    function isKeccak256Preimage(bytes memory _candidate, bytes32 _digest) public pure returns (bool) {
         return CheckBitcoinSigs.isKeccak256Preimage(_candidate, _digest);
     }
 
@@ -99,18 +88,12 @@ library CheckBitcoinSigsDelegate {
     /// @param _outputPKH       the output pubkeyhash (hash160(recipient_pubkey))
     /// @return                 the double-sha256 (hash256) signature hash as defined by bip143
     function oneInputOneOutputSighash(
-        bytes memory _outpoint,  // 36 byte UTXO id
-        bytes20 _inputPKH,  // 20 byte hash160
-        bytes8 _inputValue,  // 8-byte LE
-        bytes8 _outputValue,  // 8-byte LE
-        bytes20 _outputPKH  // 20 byte hash160
+        bytes memory _outpoint, // 36 byte UTXO id
+        bytes20 _inputPKH, // 20 byte hash160
+        bytes8 _inputValue, // 8-byte LE
+        bytes8 _outputValue, // 8-byte LE
+        bytes20 _outputPKH // 20 byte hash160
     ) public view returns (bytes32) {
-        return CheckBitcoinSigs.oneInputOneOutputSighash(
-            _outpoint,
-            _inputPKH,
-            _inputValue,
-            _outputValue,
-            _outputPKH);
+        return CheckBitcoinSigs.oneInputOneOutputSighash(_outpoint, _inputPKH, _inputValue, _outputValue, _outputPKH);
     }
-
 }

--- a/src/Migrations.sol
+++ b/src/Migrations.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.8.4;
 
 contract Migrations {
     address public owner;
-    uint public last_completed_migration;
+    uint256 public last_completed_migration;
 
     constructor() public {
         owner = msg.sender;
@@ -12,7 +12,7 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    function setCompleted(uint completed) public restricted {
+    function setCompleted(uint256 completed) public restricted {
         last_completed_migration = completed;
     }
 

--- a/src/SafeMath.sol
+++ b/src/SafeMath.sol
@@ -25,13 +25,11 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-
 /**
  * @title SafeMath
  * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
-
     /**
      * @dev Multiplies two numbers, throws on overflow.
      */

--- a/src/SegWitUtils.sol
+++ b/src/SegWitUtils.sol
@@ -11,26 +11,18 @@ library SegWitUtils {
     uint256 public constant COINBASE_WITNESS_PK_SCRIPT_LENGTH = 38;
     bytes1 public constant TAPROOT_ANNEX_PREFIX = 0x50;
 
-    function isWitnessCommitment(
-        bytes memory pkScript
-    ) internal pure returns (bool) {
+    function isWitnessCommitment(bytes memory pkScript) internal pure returns (bool) {
         return
-            pkScript.length >= COINBASE_WITNESS_PK_SCRIPT_LENGTH &&
-            bytes6(pkScript.slice32(0)) == WITNESS_MAGIC_BYTES;
+            pkScript.length >= COINBASE_WITNESS_PK_SCRIPT_LENGTH && bytes6(pkScript.slice32(0)) == WITNESS_MAGIC_BYTES;
     }
 
     // https://github.com/btcsuite/btcd/blob/80f5a0ffdf363cfff27d550f9e38aa262667a7f1/blockchain/merkle.go#L192
-    function extractWitnessCommitment(
-        bytes memory _vout
-    ) internal pure returns (bytes32) {
+    function extractWitnessCommitment(bytes memory _vout) internal pure returns (bytes32) {
         uint256 _varIntDataLen;
         uint256 _nOuts;
 
         (_varIntDataLen, _nOuts) = _vout.parseVarInt();
-        require(
-            _varIntDataLen != BTCUtils.ERR_BAD_ARG,
-            "Read overrun during VarInt parsing"
-        );
+        require(_varIntDataLen != BTCUtils.ERR_BAD_ARG, "Read overrun during VarInt parsing");
 
         uint256 _len = 0;
         uint256 _offset = 1 + _varIntDataLen;
@@ -41,19 +33,13 @@ library SegWitUtils {
             bytes memory _output = _vout.slice(_offset, _len);
             if (_output[8] == hex"26") {
                 // skip 8-byte value
-                bytes memory _pkScript = _output.slice(
-                    9,
-                    COINBASE_WITNESS_PK_SCRIPT_LENGTH
-                );
+                bytes memory _pkScript = _output.slice(9, COINBASE_WITNESS_PK_SCRIPT_LENGTH);
                 if (isWitnessCommitment(_pkScript)) {
-                    return
-                        bytes32(
-                            _pkScript.slice(
-                                WITNESS_MAGIC_BYTES.length,
-                                COINBASE_WITNESS_PK_SCRIPT_LENGTH -
-                                    WITNESS_MAGIC_BYTES.length
-                            )
-                        );
+                    return bytes32(
+                        _pkScript.slice(
+                            WITNESS_MAGIC_BYTES.length, COINBASE_WITNESS_PK_SCRIPT_LENGTH - WITNESS_MAGIC_BYTES.length
+                        )
+                    );
                 }
             }
             _offset += _len;
@@ -67,18 +53,12 @@ library SegWitUtils {
     /// @param _witness  The byte array containing the witness
     /// @param _at       The position of the witness in the array
     /// @return          The length of the witness in bytes
-    function determineWitnessLengthAt(
-        bytes memory _witness,
-        uint256 _at
-    ) internal pure returns (uint256) {
+    function determineWitnessLengthAt(bytes memory _witness, uint256 _at) internal pure returns (uint256) {
         uint256 _varIntDataLen;
         uint256 _nWit;
 
         (_varIntDataLen, _nWit) = _witness.parseVarIntAt(_at);
-        require(
-            _varIntDataLen != BTCUtils.ERR_BAD_ARG,
-            "Read overrun during VarInt parsing"
-        );
+        require(_varIntDataLen != BTCUtils.ERR_BAD_ARG, "Read overrun during VarInt parsing");
 
         uint256 _len = 0;
         uint256 _offset = 1 + _varIntDataLen;
@@ -97,10 +77,7 @@ library SegWitUtils {
     /// @param _witnessVector  The witness as a tightly-packed byte array
     /// @param _index          The 0-indexed location of the witness to extract
     /// @return                The witness vector as a byte array
-    function extractWitnessAtIndex(
-        bytes memory _witnessVector,
-        uint256 _index
-    ) internal pure returns (bytes memory) {
+    function extractWitnessAtIndex(bytes memory _witnessVector, uint256 _index) internal pure returns (bytes memory) {
         uint256 _len = 0;
         uint256 _offset = 0;
 
@@ -118,17 +95,12 @@ library SegWitUtils {
     }
 
     // https://github.com/rust-bitcoin/rust-bitcoin/blob/8aa5501827a0dd5b27abf304a5f9bdefb07a2cc6/bitcoin/src/blockdata/witness.rs#L386-L406
-    function extractTapscript(
-        bytes memory _witness
-    ) internal pure returns (bytes memory) {
+    function extractTapscript(bytes memory _witness) internal pure returns (bytes memory) {
         uint256 _varIntDataLen;
         uint256 _nWit;
 
         (_varIntDataLen, _nWit) = _witness.parseVarInt();
-        require(
-            _varIntDataLen != BTCUtils.ERR_BAD_ARG,
-            "Read overrun during VarInt parsing"
-        );
+        require(_varIntDataLen != BTCUtils.ERR_BAD_ARG, "Read overrun during VarInt parsing");
 
         uint256[] memory _offsets = new uint256[](_nWit);
 
@@ -143,9 +115,7 @@ library SegWitUtils {
         }
 
         uint256 scriptPosFromLast = 2;
-        if (
-            _nWit >= 2 && _witness[_offsets[_nWit - 1]] == TAPROOT_ANNEX_PREFIX
-        ) {
+        if (_nWit >= 2 && _witness[_offsets[_nWit - 1]] == TAPROOT_ANNEX_PREFIX) {
             scriptPosFromLast = 3;
         }
 

--- a/src/ValidateSPV.sol
+++ b/src/ValidateSPV.sol
@@ -1,22 +1,36 @@
 pragma solidity ^0.8.4;
 
-/** @title ValidateSPV*/
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title ValidateSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {BytesLib} from "./BytesLib.sol";
 import {SafeMath} from "./SafeMath.sol";
 import {BTCUtils} from "./BTCUtils.sol";
 
-
 library ValidateSPV {
-
     using BTCUtils for bytes;
     using BTCUtils for uint256;
     using BytesLib for bytes;
     using SafeMath for uint256;
 
-    enum InputTypes { NONE, LEGACY, COMPATIBILITY, WITNESS }
-    enum OutputTypes { NONE, WPKH, WSH, OP_RETURN, PKH, SH, NONSTANDARD }
+    enum InputTypes {
+        NONE,
+        LEGACY,
+        COMPATIBILITY,
+        WITNESS
+    }
+    enum OutputTypes {
+        NONE,
+        WPKH,
+        WSH,
+        OP_RETURN,
+        PKH,
+        SH,
+        NONSTANDARD
+    }
 
     uint256 constant ERR_BAD_LENGTH = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     uint256 constant ERR_INVALID_CHAIN = 0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe;
@@ -41,24 +55,18 @@ library ValidateSPV {
     /// @param _intermediateNodes   The proof's intermediate nodes (digests between leaf and root)
     /// @param _index               The leaf's index in the tree (0-indexed)
     /// @return                     true if fully valid, false otherwise
-    function prove(
-        bytes32 _txid,
-        bytes32 _merkleRoot,
-        bytes memory _intermediateNodes,
-        uint _index
-    ) internal view returns (bool) {
+    function prove(bytes32 _txid, bytes32 _merkleRoot, bytes memory _intermediateNodes, uint256 _index)
+        internal
+        view
+        returns (bool)
+    {
         // Shortcut the empty-block case
         if (_txid == _merkleRoot && _index == 0 && _intermediateNodes.length == 0) {
             return true;
         }
 
         // If the Merkle proof failed, bubble up error
-        return BTCUtils.verifyHash256Merkle(
-            _txid,
-            _intermediateNodes,
-            _merkleRoot,
-            _index
-        );
+        return BTCUtils.verifyHash256Merkle(_txid, _intermediateNodes, _merkleRoot, _index);
     }
 
     /// @notice             Hashes transaction to get txid
@@ -68,12 +76,11 @@ library ValidateSPV {
     /// @param _vout        Raw bytes length-prefixed output vector
     /// @param _locktime    4-byte tx locktime
     /// @return             32-byte transaction id, little endian
-    function calculateTxId(
-        bytes4 _version,
-        bytes memory _vin,
-        bytes memory _vout,
-        bytes4 _locktime
-    ) internal view returns (bytes32) {
+    function calculateTxId(bytes4 _version, bytes memory _vin, bytes memory _vout, bytes4 _locktime)
+        internal
+        view
+        returns (bytes32)
+    {
         // Get transaction hash double-Sha256(version + nIns + inputs + nOuts + outputs + locktime)
         return abi.encodePacked(_version, _vin, _vout, _locktime).hash256View();
     }
@@ -82,12 +89,9 @@ library ValidateSPV {
     /// @notice                  Compares the hash of each header to the prevHash in the next header
     /// @param headers           Raw byte array of header chain
     /// @return totalDifficulty  The total accumulated difficulty of the header chain, or an error code
-    function validateHeaderChain(
-        bytes memory headers
-    ) internal view returns (uint256 totalDifficulty) {
-
+    function validateHeaderChain(bytes memory headers) internal view returns (uint256 totalDifficulty) {
         // Check header chain length
-        if (headers.length % 80 != 0) {return ERR_BAD_LENGTH;}
+        if (headers.length % 80 != 0) return ERR_BAD_LENGTH;
 
         // Initialize header start index
         bytes32 digest;
@@ -95,10 +99,9 @@ library ValidateSPV {
         totalDifficulty = 0;
 
         for (uint256 start = 0; start < headers.length; start += 80) {
-
             // After the first header, check that headers are in a chain
             if (start != 0) {
-                if (!validateHeaderPrevHash(headers, start, digest)) {return ERR_INVALID_CHAIN;}
+                if (!validateHeaderPrevHash(headers, start, digest)) return ERR_INVALID_CHAIN;
             }
 
             // ith header target
@@ -106,7 +109,7 @@ library ValidateSPV {
 
             // Require that the header has sufficient work
             digest = headers.hash256Slice(start, 80);
-            if(uint256(digest).reverseUint256() > target) {
+            if (uint256(digest).reverseUint256() > target) {
                 return ERR_LOW_WORK;
             }
 
@@ -119,11 +122,8 @@ library ValidateSPV {
     /// @param digest       Header digest
     /// @param target       The target threshold
     /// @return             true if header work is valid, false otherwise
-    function validateHeaderWork(
-        bytes32 digest,
-        uint256 target
-    ) internal pure returns (bool) {
-        if (digest == bytes32(0)) {return false;}
+    function validateHeaderWork(bytes32 digest, uint256 target) internal pure returns (bool) {
+        if (digest == bytes32(0)) return false;
         return (uint256(digest).reverseUint256() < target);
     }
 
@@ -133,17 +133,16 @@ library ValidateSPV {
     /// @param at                   The position of the header
     /// @param prevHeaderDigest     The previous header's digest
     /// @return                     true if the connect is valid, false otherwise
-    function validateHeaderPrevHash(
-        bytes memory headers,
-        uint256 at,
-        bytes32 prevHeaderDigest
-    ) internal pure returns (bool) {
-
+    function validateHeaderPrevHash(bytes memory headers, uint256 at, bytes32 prevHeaderDigest)
+        internal
+        pure
+        returns (bool)
+    {
         // Extract prevHash of current header
         bytes32 prevHash = headers.extractPrevBlockLEAt(at);
 
         // Compare prevHash of current header to previous header's digest
-        if (prevHash != prevHeaderDigest) {return false;}
+        if (prevHash != prevHeaderDigest) return false;
 
         return true;
     }

--- a/src/ValidateSPVDelegate.sol
+++ b/src/ValidateSPVDelegate.sol
@@ -1,10 +1,12 @@
 pragma solidity ^0.8.4;
 
-/** @title ValidateSPV*/
-/** @author Summa (https://summa.one) */
-
+/**
+ * @title ValidateSPV
+ */
+/**
+ * @author Summa (https://summa.one)
+ */
 import {ValidateSPV} from "./ValidateSPV.sol";
-
 
 library ValidateSPVDelegate {
     function getErrBadLength() public pure returns (uint256) {
@@ -26,12 +28,11 @@ library ValidateSPVDelegate {
     /// @param _proof           The proof (concatenated LE hashes)
     /// @param _index           The proof index
     /// @return                 true if fully valid, false otherwise
-    function prove(
-        bytes32 _txid,
-        bytes32 _merkleRoot,
-        bytes memory _proof,
-        uint _index
-    ) public view returns (bool) {
+    function prove(bytes32 _txid, bytes32 _merkleRoot, bytes memory _proof, uint256 _index)
+        public
+        view
+        returns (bool)
+    {
         return ValidateSPV.prove(_txid, _merkleRoot, _proof, _index);
     }
 
@@ -42,12 +43,11 @@ library ValidateSPVDelegate {
     /// @param _vout        Raw bytes length-prefixed output vector
     /// @ param _locktime   4-byte tx locktime
     /// @return             32-byte transaction id, little endian
-    function calculateTxId(
-        bytes4 _version,
-        bytes memory _vin,
-        bytes memory _vout,
-        bytes4 _locktime
-    ) public view returns (bytes32) {
+    function calculateTxId(bytes4 _version, bytes memory _vin, bytes memory _vout, bytes4 _locktime)
+        public
+        view
+        returns (bytes32)
+    {
         return ValidateSPV.calculateTxId(_version, _vin, _vout, _locktime);
     }
 

--- a/test/BTCUtils.t.sol
+++ b/test/BTCUtils.t.sol
@@ -178,19 +178,46 @@ contract BTCUtilsTest is Test {
     }
 
     function test_ExtractsTheHashFromAStandardOutput() public {
-        ExtractHashTest[3] memory testCases = [
+        ExtractHashTest[9] memory testCases = [
+            // p2wsh
             ExtractHashTest({
                 input: hex"4897070000000000220020a4333e5612ab1a1043b25755c89b16d55184a42f81799e623e6bc39db8539c18",
                 output: hex"a4333e5612ab1a1043b25755c89b16d55184a42f81799e623e6bc39db8539c18"
             }),
+            // p2wpkh
+            ExtractHashTest({
+                input: hex"0000000000000000160014841b80d2cc75f5345c482af96294d04fdd66b2b7",
+                output: hex"841b80d2cc75f5345c482af96294d04fdd66b2b7"
+            }),
+            // p2pkh
             ExtractHashTest({
                 input: hex"00000000000000001976a914000000000000000000000000000000000000000088ac",
                 output: hex"0000000000000000000000000000000000000000"
             }),
+            // p2sh
             ExtractHashTest({
                 input: hex"000000000000000017a914000000000000000000000000000000000000000087",
                 output: hex"0000000000000000000000000000000000000000"
-            })
+            }),
+            // p2tr
+            ExtractHashTest({
+                input: hex"00000000000000002251200f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667",
+                output: hex"0f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a667"
+            }),
+            // empty
+            ExtractHashTest({input: hex"0000000000000000000000", output: hex""}),
+            // too short
+            ExtractHashTest({
+                input: hex"4897070000000000200018a4333e5612ab1a1043b25755c89b16d55184a42f81799e623e6bc39db8539c",
+                output: hex""
+            }),
+            // too long
+            ExtractHashTest({
+                input: hex"00000000000000002451220f0c8db753acbd17343a39c2f3f4e35e4be6da749f9e35137ab220e7b238a66767",
+                output: hex""
+            }),
+            // invalid tag
+            ExtractHashTest({input: hex"000000000000000017a814000000000000000000000000000000000000000087", output: hex""})
         ];
 
         for (uint256 i = 0; i < testCases.length; i++) {

--- a/test/BTCUtils.t.sol
+++ b/test/BTCUtils.t.sol
@@ -28,17 +28,11 @@ contract BTCUtilsTest is Test {
 
     function test_ReversesEndianness() public {
         ReverseEndiannessTest[2] memory testCases = [
-            ReverseEndiannessTest({
-                input: hex"00112233",
-                output: hex"33221100"
-            }),
-            ReverseEndiannessTest({
-                input: hex"0123456789abcdef",
-                output: hex"efcdab8967452301"
-            })
+            ReverseEndiannessTest({input: hex"00112233", output: hex"33221100"}),
+            ReverseEndiannessTest({input: hex"0123456789abcdef", output: hex"efcdab8967452301"})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bytes memory res = instance.reverseEndianness(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
@@ -46,45 +40,28 @@ contract BTCUtilsTest is Test {
 
     struct BytesToUintTest {
         bytes input;
-        uint output;
+        uint256 output;
     }
 
     function test_ConvertsBigEndianBytesToIntegers() public {
         BytesToUintTest[6] memory testCases = [
-            BytesToUintTest({
-                input: hex"00",
-                output: 0
-            }),
-            BytesToUintTest({
-                input: hex"ff",
-                output: 255
-            }),
-            BytesToUintTest({
-                input: hex"ff00",
-                output: 65280
-            }),
-            BytesToUintTest({
-                input: hex"01",
-                output: 1
-            }),
-            BytesToUintTest({
-                input: hex"0001",
-                output: 1
-            }),
-            BytesToUintTest({
-                input: hex"0100",
-                output: 256
-            })
+            BytesToUintTest({input: hex"00", output: 0}),
+            BytesToUintTest({input: hex"ff", output: 255}),
+            BytesToUintTest({input: hex"ff00", output: 65280}),
+            BytesToUintTest({input: hex"01", output: 1}),
+            BytesToUintTest({input: hex"0001", output: 1}),
+            BytesToUintTest({input: hex"0100", output: 256})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            uint res = instance.bytesToUint(testCases[i].input);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            uint256 res = instance.bytesToUint(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
     }
 
     function test_ImplementsBitcoinsHash160() public {
-        bytes memory input = hex"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        bytes memory input =
+            hex"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
         bytes memory output = hex"1b60c31dba9403c74d81af255f0c300bfed5faa3";
 
         bytes memory res1 = instance.hash160(input);
@@ -101,17 +78,11 @@ contract BTCUtilsTest is Test {
 
     function test_ImplementsBitcoinsHash256() public {
         Hash256Test[2] memory testCases = [
-            Hash256Test({
-                input: hex"00",
-                output: hex"1406e05881e299367766d313e26c05564ec91bf721d31726bd6e46e60689539a"
-            }),
-            Hash256Test({
-                input: hex"616263",
-                output: hex"4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358"
-            })
+            Hash256Test({input: hex"00", output: hex"1406e05881e299367766d313e26c05564ec91bf721d31726bd6e46e60689539a"}),
+            Hash256Test({input: hex"616263", output: hex"4f8b42c22dd3729b519ba6f68d2da7cc5b2d606d05daed5ad5128cc03e6c6358"})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bytes32 res1 = instance.hash256(testCases[i].input);
             assertEq(res1, testCases[i].output);
 
@@ -140,7 +111,7 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bytes32 res = instance._hash256MerkleStep(testCases[i].inputLeft, testCases[i].inputRight);
             assertEq(res, testCases[i].output);
         }
@@ -148,25 +119,26 @@ contract BTCUtilsTest is Test {
 
     function test_ExtractsASequenceFromAWitnessInputAsLEAndInt() public {
         bytes memory input = hex"1746bd867400f3494b8f44c24b83e1aa58c4f0ff25b4a61cffeffd4bc0f9ba300000000000ffffffff";
-        
+
         bytes4 res1 = instance.extractSequenceLEWitness(input);
         bytes4 output1 = hex"ffffffff";
         assertEq(res1, output1);
 
-        uint res2 = instance.extractSequenceWitness(input);
-        uint output2 = 4294967295;
+        uint256 res2 = instance.extractSequenceWitness(input);
+        uint256 output2 = 4294967295;
         assertEq(res2, output2);
     }
 
     function test_ExtractsASequenceFromALegacyInputAsLEAndInt() public {
-        bytes memory input = hex"1746bd867400f3494b8f44c24b83e1aa58c4f0ff25b4a61cffeffd4bc0f9ba3000000000203232323232323232323232323232323232323232323232323232323232323232ffffffff";
-        
+        bytes memory input =
+            hex"1746bd867400f3494b8f44c24b83e1aa58c4f0ff25b4a61cffeffd4bc0f9ba3000000000203232323232323232323232323232323232323232323232323232323232323232ffffffff";
+
         bytes4 res1 = instance.extractSequenceLELegacy(input);
         bytes4 output1 = hex"ffffffff";
         assertEq(res1, output1);
 
-        uint res2 = instance.extractSequenceLegacy(input);
-        uint output2 = 4294967295;
+        uint256 res2 = instance.extractSequenceLegacy(input);
+        uint256 output2 = 4294967295;
         assertEq(res2, output2);
     }
 
@@ -221,7 +193,7 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bytes memory res = instance.extractHash(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
@@ -230,7 +202,7 @@ contract BTCUtilsTest is Test {
     struct ExtractValueTest {
         bytes input;
         bytes8 outputRaw;
-        uint output;
+        uint256 output;
     }
 
     function test_ExtractsTheValueAsLEAndInt() public {
@@ -247,19 +219,18 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bytes8 res1 = instance.extractValueLE(testCases[i].input);
             assertEq(res1, testCases[i].outputRaw);
 
-            uint res2 = instance.extractValue(testCases[i].input);
+            uint256 res2 = instance.extractValue(testCases[i].input);
             assertEq(res2, testCases[i].output);
-
         }
     }
 
     struct DetermineInputLengthTest {
         bytes input;
-        uint output;
+        uint256 output;
     }
 
     function test_DeterminesInputLength() public {
@@ -286,8 +257,8 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            uint res = instance.determineInputLength(testCases[i].input);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            uint256 res = instance.determineInputLength(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
     }
@@ -306,7 +277,7 @@ contract BTCUtilsTest is Test {
 
     struct ExtractInputAtIndexTest {
         bytes inputVin;
-        uint inputIndex;
+        uint256 inputIndex;
         bytes output;
     }
 
@@ -347,18 +318,15 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            bytes memory res = instance.extractInputAtIndex(
-                testCases[i].inputVin,
-                testCases[i].inputIndex
-            );
+        for (uint256 i = 0; i < testCases.length; i++) {
+            bytes memory res = instance.extractInputAtIndex(testCases[i].inputVin, testCases[i].inputIndex);
             assertEq(res, testCases[i].output);
         }
     }
 
     struct ExtractInputAtIndexErrorTest {
         bytes inputVin;
-        uint inputIndex;
+        uint256 inputIndex;
         bytes errorMessage;
     }
 
@@ -402,12 +370,9 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             vm.expectRevert(testCases[i].errorMessage);
-            instance.extractInputAtIndex(
-                testCases[i].inputVin,
-                testCases[i].inputIndex
-            );
+            instance.extractInputAtIndex(testCases[i].inputVin, testCases[i].inputIndex);
         }
     }
 
@@ -428,7 +393,7 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bool res = instance.isLegacyInput(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
@@ -459,7 +424,7 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bytes memory res = instance.extractScriptSig(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
@@ -472,8 +437,8 @@ contract BTCUtilsTest is Test {
 
     struct ExtractScriptSigLenTest {
         bytes input;
-        uint output1;
-        uint output2;
+        uint256 output1;
+        uint256 output2;
     }
 
     function test_ExtractsTheLengthOfTheVarIntAndScriptSigFromInputs() public {
@@ -495,7 +460,7 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             (uint256 res1, uint256 res2) = instance.extractScriptSigLen(testCases[i].input);
             assertEq(res1, testCases[i].output1);
             assertEq(res2, testCases[i].output2);
@@ -544,13 +509,10 @@ contract BTCUtilsTest is Test {
                 output: false
             }),
             // Read overrun
-            ValidateVinTest({
-                input: hex"FF",
-                output: false
-            })
+            ValidateVinTest({input: hex"FF", output: false})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bool res = instance.validateVin(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
@@ -601,18 +563,12 @@ contract BTCUtilsTest is Test {
                 output: false
             }),
             // Read overrun
-            ValidateVoutTest({
-                input: hex"FF",
-                output: false
-            }),
+            ValidateVoutTest({input: hex"FF", output: false}),
             // Read overrun
-            ValidateVoutTest({
-                input: hex"010102030405060708FF",
-                output: false
-            })
+            ValidateVoutTest({input: hex"010102030405060708FF", output: false})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bool res = instance.validateVout(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
@@ -620,55 +576,31 @@ contract BTCUtilsTest is Test {
 
     struct DetermineOutputLengthTest {
         bytes input;
-        uint output;
+        uint256 output;
     }
 
     function test_DeterminesOutputLengthProperly() public {
         DetermineOutputLengthTest[8] memory testCases = [
-            DetermineOutputLengthTest({
-                input: hex"00000000000000002200",
-                output: 43
-            }),
-            DetermineOutputLengthTest({
-                input: hex"00000000000000001600",
-                output: 31
-            }),
-            DetermineOutputLengthTest({
-                input: hex"0000000000000000206a",
-                output: 41
-            }),
-            DetermineOutputLengthTest({
-                input: hex"000000000000000002",
-                output: 11
-            }),
-            DetermineOutputLengthTest({
-                input: hex"000000000000000000",
-                output: 9
-            }),
-            DetermineOutputLengthTest({
-                input: hex"000000000000000088",
-                output: 145
-            }),
-            DetermineOutputLengthTest({
-                input: hex"0000000000000000fc",
-                output: 261
-            }),
+            DetermineOutputLengthTest({input: hex"00000000000000002200", output: 43}),
+            DetermineOutputLengthTest({input: hex"00000000000000001600", output: 31}),
+            DetermineOutputLengthTest({input: hex"0000000000000000206a", output: 41}),
+            DetermineOutputLengthTest({input: hex"000000000000000002", output: 11}),
+            DetermineOutputLengthTest({input: hex"000000000000000000", output: 9}),
+            DetermineOutputLengthTest({input: hex"000000000000000088", output: 145}),
+            DetermineOutputLengthTest({input: hex"0000000000000000fc", output: 261}),
             // Non-minimal VarInt encoding
-            DetermineOutputLengthTest({
-                input: hex"0000000000000000FFfc00000000000000",
-                output: 269
-            })
+            DetermineOutputLengthTest({input: hex"0000000000000000FFfc00000000000000", output: 269})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            uint res = instance.determineOutputLength(testCases[i].input);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            uint256 res = instance.determineOutputLength(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
     }
 
     struct ExtractOutputAtIndexTest {
         bytes inputVout;
-        uint inputIndex;
+        uint256 inputIndex;
         bytes output;
     }
 
@@ -714,18 +646,15 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            bytes memory res = instance.extractOutputAtIndex(
-                testCases[i].inputVout,
-                testCases[i].inputIndex
-            );
+        for (uint256 i = 0; i < testCases.length; i++) {
+            bytes memory res = instance.extractOutputAtIndex(testCases[i].inputVout, testCases[i].inputIndex);
             assertEq(res, testCases[i].output);
         }
     }
 
     struct ExtractOutputAtIndexErrorTest {
         bytes inputVout;
-        uint inputIndex;
+        uint256 inputIndex;
         bytes errorMessage;
     }
 
@@ -781,17 +710,15 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             vm.expectRevert(testCases[i].errorMessage);
-            instance.extractOutputAtIndex(
-                testCases[i].inputVout,
-                testCases[i].inputIndex
-            );
+            instance.extractOutputAtIndex(testCases[i].inputVout, testCases[i].inputIndex);
         }
     }
 
     function test_ExtractsARootFromAHeader() public {
-        bytes memory input = hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
+        bytes memory input =
+            hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
         bytes32 output = hex"ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d";
 
         bytes32 res = instance.extractMerkleRootLE(input);
@@ -799,15 +726,17 @@ contract BTCUtilsTest is Test {
     }
 
     function test_ExtractsTheTargetFromAHeader() public {
-        bytes memory input = hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
+        bytes memory input =
+            hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
         bytes32 output = hex"00000000ffff0000000000000000000000000000000000000000000000000000";
 
-        uint res = instance.extractTarget(input);
-        assertEq(res, uint(output));
+        uint256 res = instance.extractTarget(input);
+        assertEq(res, uint256(output));
     }
 
     function test_ExtractsThePrevBlockHash() public {
-        bytes memory input = hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
+        bytes memory input =
+            hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
         bytes32 output = hex"55bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000";
 
         bytes32 res = instance.extractPrevBlockLE(input);
@@ -815,16 +744,17 @@ contract BTCUtilsTest is Test {
     }
 
     function test_ExtractsATimestampFromAHeader() public {
-        bytes memory input = hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
-        uint output = 1231731025;
+        bytes memory input =
+            hex"0100000055bd840a78798ad0da853f68974f3d183e2bd1db6a842c1feecf222a00000000ff104ccb05421ab93e63f8c3ce5c2c2e9dbb37de2764b3a3175c8166562cac7d51b96a49ffff001d283e9e70";
+        uint256 output = 1231731025;
 
-        uint res = instance.extractTimestamp(input);
+        uint256 res = instance.extractTimestamp(input);
         assertEq(res, output);
     }
 
     struct VerifyHash256MerkleTest {
         bytes inputProof;
-        uint inputIndex;
+        uint256 inputIndex;
         bool output;
     }
 
@@ -855,11 +785,7 @@ contract BTCUtilsTest is Test {
                 inputIndex: 781,
                 output: true
             }),
-            VerifyHash256MerkleTest({
-                inputProof: hex"00",
-                inputIndex: 0,
-                output: false
-            }),
+            VerifyHash256MerkleTest({inputProof: hex"00", inputIndex: 0, output: false}),
             VerifyHash256MerkleTest({
                 inputProof: hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
                 inputIndex: 0,
@@ -872,18 +798,15 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            bool res = instance.verifyHash256Merkle(
-                testCases[i].inputProof,
-                testCases[i].inputIndex
-            );
+        for (uint256 i = 0; i < testCases.length; i++) {
+            bool res = instance.verifyHash256Merkle(testCases[i].inputProof, testCases[i].inputIndex);
             assertEq(res, testCases[i].output);
         }
     }
 
     struct DetermineVarIntDataLengthTest {
         bytes input;
-        uint output;
+        uint256 output;
     }
 
     function test_DeterminesVarIntDataLengthsCorrectly() public {
@@ -906,44 +829,28 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            uint res = instance.determineVarIntDataLength(testCases[i].input);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            uint256 res = instance.determineVarIntDataLength(testCases[i].input);
             assertEq(res, testCases[i].output);
         }
     }
 
     struct ParseVarIntTest {
         bytes input;
-        uint outputNumBytes;
-        uint outputEncodedInt;
+        uint256 outputNumBytes;
+        uint256 outputEncodedInt;
     }
 
     function test_ParsesVarInts() public {
         ParseVarIntTest[4] memory testCases = [
-            ParseVarIntTest({
-                input: hex"01",
-                outputNumBytes: 0,
-                outputEncodedInt: 1
-            }),
-            ParseVarIntTest({
-                input: hex"ff0000000000000000",
-                outputNumBytes: 8,
-                outputEncodedInt: 0
-            }),
-            ParseVarIntTest({
-                input: hex"fe03000000",
-                outputNumBytes: 4,
-                outputEncodedInt: 3
-            }),
-            ParseVarIntTest({
-                input: hex"fd0001",
-                outputNumBytes: 2,
-                outputEncodedInt: 256
-            })
+            ParseVarIntTest({input: hex"01", outputNumBytes: 0, outputEncodedInt: 1}),
+            ParseVarIntTest({input: hex"ff0000000000000000", outputNumBytes: 8, outputEncodedInt: 0}),
+            ParseVarIntTest({input: hex"fe03000000", outputNumBytes: 4, outputEncodedInt: 3}),
+            ParseVarIntTest({input: hex"fd0001", outputNumBytes: 2, outputEncodedInt: 256})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            (uint resNumBytes, uint resEncodedInt) = instance.parseVarInt(testCases[i].input);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            (uint256 resNumBytes, uint256 resEncodedInt) = instance.parseVarInt(testCases[i].input);
             assertEq(resNumBytes, testCases[i].outputNumBytes);
             assertEq(resEncodedInt, testCases[i].outputEncodedInt);
         }
@@ -955,40 +862,36 @@ contract BTCUtilsTest is Test {
 
     function test_ReturnsErrorForInvalidVarInts() public {
         ParseVarIntErrorTest[3] memory testCases = [
-            ParseVarIntErrorTest({
-                input: hex"fd01"
-            }),
-            ParseVarIntErrorTest({
-                input: hex"fe010000"
-            }),
-            ParseVarIntErrorTest({
-                input: hex"ff01000000000000"
-            })
+            ParseVarIntErrorTest({input: hex"fd01"}),
+            ParseVarIntErrorTest({input: hex"fe010000"}),
+            ParseVarIntErrorTest({input: hex"ff01000000000000"})
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            (uint resNumBytes, uint resEncodedInt) = instance.parseVarInt(testCases[i].input);
-            assertEq(resNumBytes, uint(bytes32(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")));
+        for (uint256 i = 0; i < testCases.length; i++) {
+            (uint256 resNumBytes, uint256 resEncodedInt) = instance.parseVarInt(testCases[i].input);
+            assertEq(
+                resNumBytes, uint256(bytes32(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))
+            );
             assertEq(resEncodedInt, 0);
         }
     }
 
     struct BlockHeader {
         bytes blockHash;
-        uint version;
+        uint256 version;
         bytes prevBlock;
         bytes merkleRoot;
-        uint timestamp;
+        uint256 timestamp;
         bytes nBits;
         bytes nonce;
-        uint difficulty;
+        uint256 difficulty;
         bytes blockHex;
-        uint height;
+        uint256 height;
     }
 
     struct RetargetAlgorithmTest {
         BlockHeader[3] input;
-        uint output;
+        uint256 output;
     }
 
     function test_CalculatesConsensusCorrectRetargets() public {
@@ -1405,32 +1308,32 @@ contract BTCUtilsTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            uint firstTimestamp = testCases[i].input[0].timestamp;
-            uint secondTimestamp = testCases[i].input[1].timestamp;
-            uint previousTarget = instance.extractTarget(testCases[i].input[1].blockHex);
-            uint expectedNewTarget = instance.extractTarget(testCases[i].input[2].blockHex);
-            uint res = instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            uint256 firstTimestamp = testCases[i].input[0].timestamp;
+            uint256 secondTimestamp = testCases[i].input[1].timestamp;
+            uint256 previousTarget = instance.extractTarget(testCases[i].input[1].blockHex);
+            uint256 expectedNewTarget = instance.extractTarget(testCases[i].input[2].blockHex);
+            uint256 res = instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp);
             assertEq(res & expectedNewTarget, expectedNewTarget);
 
-            uint secondTimestamp1 = firstTimestamp + 5 * 2016 * 10 * 60; // longer than 4x
-            uint res1 = instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp1);
+            uint256 secondTimestamp1 = firstTimestamp + 5 * 2016 * 10 * 60; // longer than 4x
+            uint256 res1 = instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp1);
             assertEq((res1 / 4) & previousTarget, previousTarget);
 
-            uint secondTimestamp2 = firstTimestamp + 2016 * 10 * 14; // shorter than 1/4x
-            uint res2 = instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp2);
-            assertEq((res2 * 4) & previousTarget, previousTarget);      
+            uint256 secondTimestamp2 = firstTimestamp + 2016 * 10 * 14; // shorter than 1/4x
+            uint256 res2 = instance.retargetAlgorithm(previousTarget, firstTimestamp, secondTimestamp2);
+            assertEq((res2 * 4) & previousTarget, previousTarget);
         }
 
         // extracts difficulty from a header
-        for (uint i = 0; i < testCases.length; i++) {
-            uint res1 = instance.extractDifficulty(testCases[i].input[0].blockHex);
+        for (uint256 i = 0; i < testCases.length; i++) {
+            uint256 res1 = instance.extractDifficulty(testCases[i].input[0].blockHex);
             assertEq(res1, testCases[i].input[0].difficulty);
 
-            uint res2 = instance.extractDifficulty(testCases[i].input[1].blockHex);
+            uint256 res2 = instance.extractDifficulty(testCases[i].input[1].blockHex);
             assertEq(res2, testCases[i].input[1].difficulty);
 
-            uint res3 = instance.extractDifficulty(testCases[i].input[2].blockHex);
+            uint256 res3 = instance.extractDifficulty(testCases[i].input[2].blockHex);
             assertEq(res3, testCases[i].input[2].difficulty);
         }
     }

--- a/test/CheckBitcoinSigs.t.sol
+++ b/test/CheckBitcoinSigs.t.sol
@@ -7,36 +7,41 @@ import {CheckBitcoinSigsScript} from "../script/CheckBitcoinSigs.s.sol";
 contract CheckBitcoinSigsTest is Test {
     CheckBitcoinSigsScript public instance;
 
-    bytes32 constant EMPTY = hex'0000000000000000000000000000000000000000000000000000000000000000';
+    bytes32 constant EMPTY = hex"0000000000000000000000000000000000000000000000000000000000000000";
 
     function setUp() public {
         instance = new CheckBitcoinSigsScript();
     }
 
-    bytes pubkey = hex'4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1';
-    bytes32 digest = hex'02d449a31fbb267c8f352e9968a79e3e5fc95c1bbeaa502fd6454ebde5a4bedc';
+    bytes pubkey =
+        hex"4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1";
+    bytes32 digest = hex"02d449a31fbb267c8f352e9968a79e3e5fc95c1bbeaa502fd6454ebde5a4bedc";
     uint8 v = 27;
-    bytes32 r = hex'd7e83e8687ba8b555f553f22965c74e81fd08b619a7337c5c16e4b02873b537e';
-    bytes32 s = hex'633bf745cdf7ae303ca8a6f41d71b2c3a21fcbd1aed9e7ffffa295c08918c1b3';
+    bytes32 r = hex"d7e83e8687ba8b555f553f22965c74e81fd08b619a7337c5c16e4b02873b537e";
+    bytes32 s = hex"633bf745cdf7ae303ca8a6f41d71b2c3a21fcbd1aed9e7ffffa295c08918c1b3";
 
     // #accountFromPubkey
 
     function test_GeneratesAnAccountFromAPubkey() public {
-        address res = instance.accountFromPubkey(hex'33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333');
+        address res = instance.accountFromPubkey(
+            hex"33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333"
+        );
         assertEq(res, 0x183671Cd69C7f9a760F9f1c59393Df69e893e557);
     }
 
     function test_ErrorsIfTheInputLengthIsWrong() public {
         vm.expectRevert("Pubkey must be 64-byte raw, uncompressed key.");
-        instance.accountFromPubkey(hex'33');
+        instance.accountFromPubkey(hex"33");
     }
 
     // #p2wpkhFromPubkey
 
-    bytes uncompressed = hex'3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b13b306b0fe085665d8fc1b28ae1676cd3ad6e08eaeda225fe38d0da4de55703e0';
-    bytes compressed = hex'023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1';
-    bytes prefixedUncompressed = hex'043c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b13b306b0fe085665d8fc1b28ae1676cd3ad6e08eaeda225fe38d0da4de55703e0';
-    bytes outputScript = hex'00143bc28d6d92d9073fb5e3adf481795eaf446bceed';
+    bytes uncompressed =
+        hex"3c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b13b306b0fe085665d8fc1b28ae1676cd3ad6e08eaeda225fe38d0da4de55703e0";
+    bytes compressed = hex"023c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b1";
+    bytes prefixedUncompressed =
+        hex"043c72addb4fdf09af94f0c94d7fe92a386a7e70cf8a1d85916386bb2535c7b1b13b306b0fe085665d8fc1b28ae1676cd3ad6e08eaeda225fe38d0da4de55703e0";
+    bytes outputScript = hex"00143bc28d6d92d9073fb5e3adf481795eaf446bceed";
 
     function test_HandlesUnprefixedUncompressedKeys() public {
         bytes memory res = instance.p2wpkhFromPubkey(uncompressed);
@@ -55,7 +60,7 @@ contract CheckBitcoinSigsTest is Test {
 
     function test_ErrorsOnNonStandardKeyFormats() public {
         vm.expectRevert("Witness PKH requires compressed keys");
-        instance.p2wpkhFromPubkey(hex'');
+        instance.p2wpkhFromPubkey(hex"");
     }
 
     // #checkSig
@@ -75,15 +80,15 @@ contract CheckBitcoinSigsTest is Test {
 
     function test_SigErrorsOnWeirdPubkeyLengths() public {
         vm.expectRevert("Requires uncompressed unprefixed pubkey");
-        instance.checkSig(hex'00', EMPTY, 1, EMPTY, EMPTY);
+        instance.checkSig(hex"00", EMPTY, 1, EMPTY, EMPTY);
     }
 
     // #checkBitcoinSig
 
-    bytes witnessScript = hex'0014fc7250a211deddc70ee5a2738de5f07817351cef';
+    bytes witnessScript = hex"0014fc7250a211deddc70ee5a2738de5f07817351cef";
 
     function test_ReturnsFalseIfThePubkeyDoesNotMatchTheWitnessScript() public {
-        bool res = instance.checkBitcoinSig(hex'00', pubkey, EMPTY, 1, EMPTY, EMPTY);
+        bool res = instance.checkBitcoinSig(hex"00", pubkey, EMPTY, 1, EMPTY, EMPTY);
         assertEq(res, false);
     }
 
@@ -99,25 +104,49 @@ contract CheckBitcoinSigsTest is Test {
 
     function test_BitcoinSigErrorsOnWeirdPubkeyLengths() public {
         vm.expectRevert("Requires uncompressed unprefixed pubkey");
-        bool res = instance.checkBitcoinSig(hex'00', hex'00', EMPTY, 1, EMPTY, EMPTY);
+        bool res = instance.checkBitcoinSig(hex"00", hex"00", EMPTY, 1, EMPTY, EMPTY);
     }
 
     // #isSha256Preimage
 
     function test_IdentifiesSha256Preimages() public {
-        assertEq(instance.isSha256Preimage(hex'01', hex'4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a'), true);
-        assertEq(instance.isSha256Preimage(hex'02', hex'dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986'), true);
-        assertEq(instance.isSha256Preimage(hex'03', hex'084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5'), true);
-        assertEq(instance.isSha256Preimage(hex'04', hex'084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5'), false);
+        assertEq(
+            instance.isSha256Preimage(hex"01", hex"4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"),
+            true
+        );
+        assertEq(
+            instance.isSha256Preimage(hex"02", hex"dbc1b4c900ffe48d575b5da5c638040125f65db0fe3e24494b76ea986457d986"),
+            true
+        );
+        assertEq(
+            instance.isSha256Preimage(hex"03", hex"084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5"),
+            true
+        );
+        assertEq(
+            instance.isSha256Preimage(hex"04", hex"084fed08b978af4d7d196a7446a86b58009e636b611db16211b65a9aadff29c5"),
+            false
+        );
     }
 
     // #isKeccak256Preimage
 
     function test_IdentifiesKeccak256Preimages() public {
-        assertEq(instance.isKeccak256Preimage(hex'01', hex'5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2'), true);
-        assertEq(instance.isKeccak256Preimage(hex'02', hex'f2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2'), true);
-        assertEq(instance.isKeccak256Preimage(hex'03', hex'69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287'), true);
-        assertEq(instance.isKeccak256Preimage(hex'04', hex'69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287'), false);
+        assertEq(
+            instance.isKeccak256Preimage(hex"01", hex"5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2"),
+            true
+        );
+        assertEq(
+            instance.isKeccak256Preimage(hex"02", hex"f2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2"),
+            true
+        );
+        assertEq(
+            instance.isKeccak256Preimage(hex"03", hex"69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287"),
+            true
+        );
+        assertEq(
+            instance.isKeccak256Preimage(hex"04", hex"69c322e3248a5dfc29d73c5b0553b0185a35cd5bb6386747517ef7e53b15e287"),
+            false
+        );
     }
 
     // #oneInputOneOutputSighash
@@ -127,20 +156,14 @@ contract CheckBitcoinSigsTest is Test {
         // 01000000000101333333333333333333333333333333333333333333333333333333333333333333333333000000000001111111110000000016001433333333333333333333333333333333333333330000000000
         // the sighash preimage will be:
         // 010000003fc8fd9fada5a3573744477d5e35b0d4d0645e42285e3dec25aac02078db0f838cb9012517c817fead650287d61bdd9c68803b6bf9c64133dcab3e65b5a50cb93333333333333333333333333333333333333333333333333333333333333333333333331976a9145eb9b5e445db673f0ed8935d18cd205b214e518788ac111111111111111100000000e4ca7a168bd64e3123edd7f39e1ab7d670b32311cac2dda8e083822139c7936c0000000001000000
-        bytes memory outpoint = hex'333333333333333333333333333333333333333333333333333333333333333333333333';
-        bytes20 inputPKH = hex'5eb9b5e445db673f0ed8935d18cd205b214e5187'; // pubkey is '02' + '33'.repeat(32)
-        bytes8 inputValue = hex'1111111111111111';
-        bytes8 outputValue = hex'1111111100000000';
-        bytes20 outputPKH = hex'3333333333333333333333333333333333333333';
-        bytes32 sighash = hex'b68a6378ddb770a82ae4779a915f0a447da7d753630f8dd3b00be8638677dd90';
+        bytes memory outpoint = hex"333333333333333333333333333333333333333333333333333333333333333333333333";
+        bytes20 inputPKH = hex"5eb9b5e445db673f0ed8935d18cd205b214e5187"; // pubkey is '02' + '33'.repeat(32)
+        bytes8 inputValue = hex"1111111111111111";
+        bytes8 outputValue = hex"1111111100000000";
+        bytes20 outputPKH = hex"3333333333333333333333333333333333333333";
+        bytes32 sighash = hex"b68a6378ddb770a82ae4779a915f0a447da7d753630f8dd3b00be8638677dd90";
 
-        bytes32 res = instance.oneInputOneOutputSighash(
-            outpoint,
-            inputPKH,
-            inputValue,
-            outputValue,
-            outputPKH    
-        );
+        bytes32 res = instance.oneInputOneOutputSighash(outpoint, inputPKH, inputValue, outputValue, outputPKH);
         assertEq(res, sighash);
     }
 }

--- a/test/SegWitUtils.t.sol
+++ b/test/SegWitUtils.t.sol
@@ -9,14 +9,13 @@ contract SegWitUtilsTest is Test {
     using SegWitUtils for bytes;
 
     function test_IsWitnessTxOut() public {
-        bytes
-            memory pkScript = hex"6a24aa21a9edaf8dcb9588f94a3adb462e80f1306d96ef6ffad72160b33cd5e90045d81e0d77";
+        bytes memory pkScript = hex"6a24aa21a9edaf8dcb9588f94a3adb462e80f1306d96ef6ffad72160b33cd5e90045d81e0d77";
         assert(pkScript.isWitnessCommitment());
     }
 
     function test_ExtractWitnessCommitmentFromTxOut() public {
-        bytes
-            memory outputVector = hex"020593cb260000000016001435f6de260c9f3bdee47524c473a6016c0c055cb90000000000000000266a24aa21a9edaf8dcb9588f94a3adb462e80f1306d96ef6ffad72160b33cd5e90045d81e0d77";
+        bytes memory outputVector =
+            hex"020593cb260000000016001435f6de260c9f3bdee47524c473a6016c0c055cb90000000000000000266a24aa21a9edaf8dcb9588f94a3adb462e80f1306d96ef6ffad72160b33cd5e90045d81e0d77";
         bytes32 witnessCommitment = outputVector.extractWitnessCommitment();
         bytes32 coinbaseWitnessCommitment = hex"af8dcb9588f94a3adb462e80f1306d96ef6ffad72160b33cd5e90045d81e0d77";
         assertEq(coinbaseWitnessCommitment, witnessCommitment);
@@ -24,8 +23,8 @@ contract SegWitUtilsTest is Test {
 
     // 120c1b297faedd14568b7f02cc15725864d0ec2a9d6a42af764c03827ccc1c72
     function test_ExtractWitnessAtIndex() public {
-        bytes
-            memory witnessVector = hex"0247304402203c643747293b2f1e3f42253e8307147fa46086f065bdaddb7540c0862e7133c2022031e9cc284d643ae1c0fc139dad929136edc7bb3454512f11a0cbc4117240e604012103608b21667ba574f0177cd505c7b33c657b0fdb62ebb913fdd537a5358a22c6ec0247304402203cbccb97dc9eac21436325d551960ae41a55f00edcb0a39e1099ecf8ab3cbf9f02200f04f061eb50de21ea0ef98ad6ba913c3ee43306f9e2d2ce57576a6beaa2e8c0012103d2296e51b33a43425c5c905afee8997a5fbfdaa8c10add4e56ea8bc5ceea2fcf";
+        bytes memory witnessVector =
+            hex"0247304402203c643747293b2f1e3f42253e8307147fa46086f065bdaddb7540c0862e7133c2022031e9cc284d643ae1c0fc139dad929136edc7bb3454512f11a0cbc4117240e604012103608b21667ba574f0177cd505c7b33c657b0fdb62ebb913fdd537a5358a22c6ec0247304402203cbccb97dc9eac21436325d551960ae41a55f00edcb0a39e1099ecf8ab3cbf9f02200f04f061eb50de21ea0ef98ad6ba913c3ee43306f9e2d2ce57576a6beaa2e8c0012103d2296e51b33a43425c5c905afee8997a5fbfdaa8c10add4e56ea8bc5ceea2fcf";
         assertEq(
             keccak256(witnessVector.extractWitnessAtIndex(0)),
             0x42d6cb8ef768d22410c78498a0370193b833b87da6985435f6ba299fa84f9ab7
@@ -37,13 +36,11 @@ contract SegWitUtilsTest is Test {
     }
 
     function test_ExtractTapscript() public {
-        bytes
-            memory witnessVector = hex"03406c00eb3c4d35fedd257051333b4ca81d1a25a37a9af4891f1fec2869edd56b14180eafbda8851d63138a724c9b15384bc5f0536de658bd294d426a36212e6f08a5209e2849b90a2353691fccedd467215c88eec89a5d0dcf468e6cf37abed344d746ac0063036f7264010118746578742f706c61696e3b636861727365743d7574662d38004c5e7b200a20202270223a20226272632d3230222c0a2020226f70223a20226465706c6f79222c0a2020227469636b223a20226f726469222c0a2020226d6178223a20223231303030303030222c0a2020226c696d223a202231303030220a7d6821c19e2849b90a2353691fccedd467215c88eec89a5d0dcf468e6cf37abed344d746";
+        bytes memory witnessVector =
+            hex"03406c00eb3c4d35fedd257051333b4ca81d1a25a37a9af4891f1fec2869edd56b14180eafbda8851d63138a724c9b15384bc5f0536de658bd294d426a36212e6f08a5209e2849b90a2353691fccedd467215c88eec89a5d0dcf468e6cf37abed344d746ac0063036f7264010118746578742f706c61696e3b636861727365743d7574662d38004c5e7b200a20202270223a20226272632d3230222c0a2020226f70223a20226465706c6f79222c0a2020227469636b223a20226f726469222c0a2020226d6178223a20223231303030303030222c0a2020226c696d223a202231303030220a7d6821c19e2849b90a2353691fccedd467215c88eec89a5d0dcf468e6cf37abed344d746";
 
         assertEq(
-            keccak256(
-                witnessVector.extractWitnessAtIndex(0).extractTapscript()
-            ),
+            keccak256(witnessVector.extractWitnessAtIndex(0).extractTapscript()),
             0xf4573d2a3472df97b6a2d9ecb0dab17eef1bebb903ecad628de8e96b0cc7ab30
         );
     }

--- a/test/ValidateSPV.t.sol
+++ b/test/ValidateSPV.t.sol
@@ -14,22 +14,22 @@ contract ValidateSPVTest is Test {
     function test_TheConstantGettersForThatSweetSweetCoverage() public {
         bytes memory getErrBadLengthOutput = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         uint256 res1 = instance.getErrBadLength();
-        assertEq(res1, uint(bytes32(getErrBadLengthOutput)));
+        assertEq(res1, uint256(bytes32(getErrBadLengthOutput)));
 
         bytes memory getErrInvalidChainOutput = hex"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe";
         uint256 res2 = instance.getErrInvalidChain();
-        assertEq(res2, uint(bytes32(getErrInvalidChainOutput)));
+        assertEq(res2, uint256(bytes32(getErrInvalidChainOutput)));
 
         bytes memory getErrLowWorkOutput = hex"fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd";
         uint256 res3 = instance.getErrLowWork();
-        assertEq(res3, uint(bytes32(getErrLowWorkOutput)));
+        assertEq(res3, uint256(bytes32(getErrLowWorkOutput)));
     }
 
     struct ProveTest {
         bytes32 inputTxIdLE;
         bytes32 inputMerkleRootLE;
         bytes inputProof;
-        uint inputIndex;
+        uint256 inputIndex;
         bool output;
     }
 
@@ -58,7 +58,7 @@ contract ValidateSPVTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             bool res = instance.prove(
                 testCases[i].inputTxIdLE,
                 testCases[i].inputMerkleRootLE,
@@ -72,7 +72,8 @@ contract ValidateSPVTest is Test {
     function test_ReturnsTheTransactionHash() public {
         bytes4 version = hex"01000000";
         bytes memory vin = hex"011746bd867400f3494b8f44c24b83e1aa58c4f0ff25b4a61cffeffd4bc0f9ba300000000000ffffffff";
-        bytes memory vout = hex"024897070000000000220020a4333e5612ab1a1043b25755c89b16d55184a42f81799e623e6bc39db8539c180000000000000000166a14edb1b5c2f39af0fec151732585b1049b07895211";
+        bytes memory vout =
+            hex"024897070000000000220020a4333e5612ab1a1043b25755c89b16d55184a42f81799e623e6bc39db8539c180000000000000000166a14edb1b5c2f39af0fec151732585b1049b07895211";
         bytes4 locktime = hex"00000000";
 
         bytes32 output = hex"48e5a1a0e616d8fd92b4ef228c424e0c816799a256c6a90892195ccfc53300d6";
@@ -82,10 +83,11 @@ contract ValidateSPVTest is Test {
     }
 
     function test_ReturnsTrueIfHeaderChainIsValid() public {
-        bytes memory input = hex"0000002073bd2184edd9c4fc76642ea6754ee40136970efc10c4190000000000000000000296ef123ea96da5cf695f22bf7d94be87d49db1ad7ac371ac43c4da4161c8c216349c5ba11928170d38782b00000020fe70e48339d6b17fbbf1340d245338f57336e97767cc240000000000000000005af53b865c27c6e9b5e5db4c3ea8e024f8329178a79ddb39f7727ea2fe6e6825d1349c5ba1192817e2d9515900000020baaea6746f4c16ccb7cd961655b636d39b5fe1519b8f15000000000000000000c63a8848a448a43c9e4402bd893f701cd11856e14cbbe026699e8fdc445b35a8d93c9c5ba1192817b945dc6c00000020f402c0b551b944665332466753f1eebb846a64ef24c71700000000000000000033fc68e070964e908d961cd11033896fa6c9b8b76f64a2db7ea928afa7e304257d3f9c5ba11928176164145d0000ff3f63d40efa46403afd71a254b54f2b495b7b0164991c2d22000000000000000000f046dc1b71560b7d0786cfbdb25ae320bd9644c98d5c7c77bf9df05cbe96212758419c5ba1192817a2bb2caa00000020e2d4f0edd5edd80bdcb880535443747c6b22b48fb6200d0000000000000000001d3799aa3eb8d18916f46bf2cf807cb89a9b1b4c56c3f2693711bf1064d9a32435429c5ba1192817752e49ae0000002022dba41dff28b337ee3463bf1ab1acf0e57443e0f7ab1d000000000000000000c3aadcc8def003ecbd1ba514592a18baddddcd3a287ccf74f584b04c5c10044e97479c5ba1192817c341f595";
-        uint output = 49134394618239;
+        bytes memory input =
+            hex"0000002073bd2184edd9c4fc76642ea6754ee40136970efc10c4190000000000000000000296ef123ea96da5cf695f22bf7d94be87d49db1ad7ac371ac43c4da4161c8c216349c5ba11928170d38782b00000020fe70e48339d6b17fbbf1340d245338f57336e97767cc240000000000000000005af53b865c27c6e9b5e5db4c3ea8e024f8329178a79ddb39f7727ea2fe6e6825d1349c5ba1192817e2d9515900000020baaea6746f4c16ccb7cd961655b636d39b5fe1519b8f15000000000000000000c63a8848a448a43c9e4402bd893f701cd11856e14cbbe026699e8fdc445b35a8d93c9c5ba1192817b945dc6c00000020f402c0b551b944665332466753f1eebb846a64ef24c71700000000000000000033fc68e070964e908d961cd11033896fa6c9b8b76f64a2db7ea928afa7e304257d3f9c5ba11928176164145d0000ff3f63d40efa46403afd71a254b54f2b495b7b0164991c2d22000000000000000000f046dc1b71560b7d0786cfbdb25ae320bd9644c98d5c7c77bf9df05cbe96212758419c5ba1192817a2bb2caa00000020e2d4f0edd5edd80bdcb880535443747c6b22b48fb6200d0000000000000000001d3799aa3eb8d18916f46bf2cf807cb89a9b1b4c56c3f2693711bf1064d9a32435429c5ba1192817752e49ae0000002022dba41dff28b337ee3463bf1ab1acf0e57443e0f7ab1d000000000000000000c3aadcc8def003ecbd1ba514592a18baddddcd3a287ccf74f584b04c5c10044e97479c5ba1192817c341f595";
+        uint256 output = 49134394618239;
 
-        uint res = instance.validateHeaderChain(input);
+        uint256 res = instance.validateHeaderChain(input);
         assertEq(res, output);
     }
 
@@ -110,10 +112,9 @@ contract ValidateSPVTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
+        for (uint256 i = 0; i < testCases.length; i++) {
             uint256 res = instance.validateHeaderChain(testCases[i].input);
             assertEq(res, uint256(testCases[i].errorValue));
-
 
             // Execute within Tx to measure gas amount
             instance.validateHeaderChainTx(testCases[i].input);
@@ -145,11 +146,8 @@ contract ValidateSPVTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            bool res = instance.validateHeaderWork(
-                testCases[i].inputDigest,
-                uint256(testCases[i].inputTarget)
-            );
+        for (uint256 i = 0; i < testCases.length; i++) {
+            bool res = instance.validateHeaderWork(testCases[i].inputDigest, uint256(testCases[i].inputTarget));
             assertEq(res, testCases[i].output);
         }
     }
@@ -174,11 +172,8 @@ contract ValidateSPVTest is Test {
             })
         ];
 
-        for (uint i = 0; i < testCases.length; i++) {
-            bool res = instance.validateHeaderPrevHash(
-                testCases[i].inputHeader,
-                testCases[i].inputPrevHash
-            );
+        for (uint256 i = 0; i < testCases.length; i++) {
+            bool res = instance.validateHeaderPrevHash(testCases[i].inputHeader, testCases[i].inputPrevHash);
             assertEq(res, testCases[i].output);
         }
     }


### PR DESCRIPTION
closes https://github.com/bob-collective/bitcoin-spv/issues/8 

We should probably rename the functions `extractHash` and `extractHashAt` since they are not necessarily extracting a hash, could be various types of payload. So I think `extractPayload` and `extractPayloadAt` would be better. 

Merge the formatting [PR](https://github.com/bob-collective/bitcoin-spv/pull/10) before this. 